### PR TITLE
Fix model list endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Reload the unpacked extension after replacing the files with a newer version.
 
 ## Configuration
 Use the extension options page to set:
-- API key and optional endpoint
-  (keep your API key private)
-- Translation model (click Refresh to fetch available models)
+- API key and optional endpoint (keep your API key private)
+- Translation model (`qwen-mt-plus` or `qwen-mt-turbo`)
+  - Click **Refresh** to retrieve the model list from the `/models` API
 - Target language and ignored languages
 - Automatic translation toggle
 The language and model lists include search boxes to make selection easier.

--- a/src/options.js
+++ b/src/options.js
@@ -35,7 +35,7 @@ async function fetchModels() {
   const endpoint = withSlash(endpointInput.value.trim());
   const key = apiKeyInput.value.trim();
   try {
-    const url = `${endpoint}services/aigc/mt/text-translator/models`;
+    const url = `${endpoint}models`;
     console.log('Fetching models from', url);
     const res = await fetch(url, {
       headers: { 'Authorization': `Bearer ${key}` }
@@ -46,11 +46,15 @@ async function fetchModels() {
     }
     const data = await res.json();
     modelSelect.innerHTML = '';
-    data.models.forEach(m => {
-      const opt = document.createElement('option');
-      opt.value = m.model; opt.textContent = m.model;
-      modelSelect.appendChild(opt);
-    });
+    const list = Array.isArray(data.models) ? data.models : data;
+    list
+      .filter(m => m.model && m.model.includes('qwen-mt'))
+      .forEach(m => {
+        const opt = document.createElement('option');
+        opt.value = m.model;
+        opt.textContent = m.model;
+        modelSelect.appendChild(opt);
+      });
     attachSearch(modelSelect, modelSearch);
   } catch (e) {
     console.error('Model fetch error:', e);


### PR DESCRIPTION
## Summary
- use `/models` API to populate model list and filter for Qwen-MT models
- document available models in README

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a2b4d13c8832385b959d6ac02bc7e