### PR TITLE
Fix missing translator in popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This Chrome extension translates the content of the active tab using Alibaba Clo
 2. Build the extension by copying the `src` folder contents into a folder of your choice.
 3. In your Chromium based browser open the extensions page and enable "Developer mode".
 4. Choose "Load unpacked" and select the folder containing the extension files.
+   The extension requests the "tabs" permission so the popup can send
+   messages to the active tab for translation.
 
 ## Uninstallation
 Remove the extension from the browser's extension management page.

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
   "version": "1.0",
-  "permissions": ["storage", "activeTab", "scripting"],
+  "permissions": ["storage", "activeTab", "tabs", "scripting"],
   "host_permissions": [
     "https://dashscope-intl.aliyuncs.com/*"
   ],
@@ -14,6 +14,12 @@
     "default_popup": "popup.html",
     "default_title": "Qwen Translator"
   },
+  "web_accessible_resources": [
+    {
+      "resources": ["translator.js", "config.js", "languages.js"],
+      "matches": ["<all_urls>"]
+    }
+  ],
   "content_scripts": [
     {
       "matches": ["<all_urls>"],

--- a/src/popup.html
+++ b/src/popup.html
@@ -21,6 +21,7 @@
   <button id="save">Save</button>
   <button id="test">Test Settings</button>
   <div id="status"></div>
+  <script src="translator.js"></script>
   <script src="config.js"></script>
   <script src="languages.js"></script>
   <script src="popup.js"></script>


### PR DESCRIPTION
## Summary
- include `translator.js` in popup page so Test Settings works
- add tabs permission for popup messaging
- expose scripts as web-accessible resources
- document the new permission in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a3b654810832397ed2dac4ecf3515