### PR TITLE
Fix browser loading errors

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -16,14 +16,14 @@
   },
   "web_accessible_resources": [
     {
-      "resources": ["translator.js", "config.js", "languages.js"],
+      "resources": ["translator.js", "config.js", "languages.js", "throttle.js"],
       "matches": ["<all_urls>"]
     }
   ],
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["config.js", "translator.js", "contentScript.js"],
+      "js": ["config.js", "throttle.js", "translator.js", "contentScript.js"],
       "run_at": "document_idle"
     }
   ]

--- a/src/translator.js
+++ b/src/translator.js
@@ -1,8 +1,19 @@
 let fetchFn = typeof fetch !== 'undefined' ? fetch : undefined;
+let runWithRateLimit;
+let approxTokens;
+
 if (typeof window === 'undefined') {
   fetchFn = require('cross-fetch');
+  ({ runWithRateLimit, approxTokens } = require('./throttle'));
+} else {
+  if (window.qwenThrottle) {
+    ({ runWithRateLimit, approxTokens } = window.qwenThrottle);
+  } else if (typeof require !== 'undefined') {
+    ({ runWithRateLimit, approxTokens } = require('./throttle'));
+  } else {
+    throw new Error('Throttle module not available');
+  }
 }
-const { runWithRateLimit, approxTokens } = require('./throttle');
 
 const cache = new Map();
 


### PR DESCRIPTION
## Summary
- load throttle.js content script so translator can use it
- use global throttle functions when running in browsers

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a4bb997208323932bc62de974da2f