### PR TITLE
Fix browser loading errors

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -16,14 +16,14 @@
   },
   "web_accessible_resources": [
     {
-      "resources": ["translator.js", "config.js", "languages.js"],
+      "resources": ["translator.js", "config.js", "languages.js", "throttle.js"],
       "matches": ["<all_urls>"]
     }
   ],
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["config.js", "translator.js", "contentScript.js"],
+      "js": ["config.js", "throttle.js", "translator.js", "contentScript.js"],
       "run_at": "document_idle"
     }
   ]

--- a/src/popup.html
+++ b/src/popup.html
@@ -23,6 +23,7 @@
   <button id="save">Save</button>
   <button id="test">Test Settings</button>
   <div id="status"></div>
+  <script src="throttle.js"></script>
   <script src="translator.js"></script>
   <script src="config.js"></script>
   <script src="languages.js"></script>

--- a/src/translator.js
+++ b/src/translator.js
@@ -1,8 +1,20 @@
 let fetchFn = typeof fetch !== 'undefined' ? fetch : undefined;
+var runWithRateLimit;
+var approxTokens;
+
 if (typeof window === 'undefined') {
   fetchFn = require('cross-fetch');
+  ({ runWithRateLimit, approxTokens } = require('./throttle'));
+} else {
+  if (window.qwenThrottle) {
+    ({ runWithRateLimit, approxTokens } = window.qwenThrottle);
+  } else if (typeof require !== 'undefined') {
+    ({ runWithRateLimit, approxTokens } = require('./throttle'));
+  } else {
+    runWithRateLimit = fn => fn();
+    approxTokens = () => 0;
+  }
 }
-const { runWithRateLimit, approxTokens } = require('./throttle');
 
 const cache = new Map();
 


### PR DESCRIPTION
## Summary
- load throttle.js content script so translator can use it
- use global throttle functions when running in browsers
- load throttle.js before translator in popup to prevent startup errors

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a4bb997208323932bc62de974da2f