### PR TITLE
Improve logging and fix background response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/background.js
+++ b/src/background.js
@@ -5,73 +5,79 @@ chrome.runtime.onInstalled.addListener(() => {
   console.log('Qwen Translator installed');
 });
 
-chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-  if (msg.action === 'translate') {
-    const { endpoint, apiKey, model, text, source, target } = msg.opts;
-    const ep = endpoint.endsWith('/') ? endpoint : `${endpoint}/`;
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 10000);
-    const url = `${ep}services/aigc/text-generation/generation`;
-    console.log('Background translating via', url);
+async function handleTranslate(opts) {
+  const { endpoint, apiKey, model, text, source, target, debug } = opts;
+  const ep = endpoint.endsWith('/') ? endpoint : `${endpoint}/`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10000);
+  const url = `${ep}services/aigc/text-generation/generation`;
+  if (debug) console.log('QTDEBUG: background translating via', url);
 
-    chrome.storage.sync.get({ requestLimit: 60, tokenLimit: 100000 }, cfg => {
-      configure({ requestLimit: cfg.requestLimit, tokenLimit: cfg.tokenLimit, windowMs: 60000 });
+  const cfg = await new Promise(resolve =>
+    chrome.storage.sync.get({ requestLimit: 60, tokenLimit: 100000 }, resolve)
+  );
+  configure({ requestLimit: cfg.requestLimit, tokenLimit: cfg.tokenLimit, windowMs: 60000 });
 
-      runWithRateLimit(() => fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: apiKey,
-          'X-DashScope-SSE': 'enable',
+  try {
+    const resp = await runWithRateLimit(() => fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: apiKey,
+        'X-DashScope-SSE': 'enable',
+      },
+      body: JSON.stringify({
+        model,
+        input: { messages: [{ role: 'user', content: text }] },
+        parameters: {
+          translation_options: { source_lang: source, target_lang: target },
         },
-        body: JSON.stringify({
-          model,
-          input: { messages: [{ role: 'user', content: text }] },
-          parameters: {
-            translation_options: { source_lang: source, target_lang: target },
-          },
-        }),
-        signal: controller.signal,
-      }), approxTokens(text))
-      .then(async resp => {
-        clearTimeout(timer);
-        if (!resp.ok) {
-          const err = await resp.json().catch(() => ({ message: resp.statusText }));
-          sendResponse({ error: `HTTP ${resp.status}: ${err.message}` });
-          return;
-        }
-        const reader = resp.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = '';
-        let result = '';
-        while (true) {
-          const { value, done } = await reader.read();
-          if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split('\n');
-          buffer = lines.pop();
-          for (const line of lines) {
-            const trimmed = line.trim();
-            if (!trimmed.startsWith('data:')) continue;
-            const data = trimmed.slice(5).trim();
-            if (data === '[DONE]') { reader.cancel(); break; }
-            try {
-              const obj = JSON.parse(data);
-              const chunk =
-                obj.output?.text ||
-                obj.output?.choices?.[0]?.message?.content || '';
-              result += chunk;
-            } catch {}
-          }
-        }
-        sendResponse({ text: result });
-      })
-      .catch(err => {
-        clearTimeout(timer);
-        console.error('Background translation error:', err);
-        sendResponse({ error: err.message });
-      });
-    });
-    return true;
+      }),
+      signal: controller.signal,
+    }), approxTokens(text));
+
+    clearTimeout(timer);
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ message: resp.statusText }));
+      if (debug) console.log('QTDEBUG: background HTTP error', err);
+      return { error: `HTTP ${resp.status}: ${err.message}` };
+    }
+
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let result = '';
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop();
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith('data:')) continue;
+        const data = trimmed.slice(5).trim();
+        if (data === '[DONE]') { reader.cancel(); break; }
+        try {
+          const obj = JSON.parse(data);
+          const chunk =
+            obj.output?.text ||
+            obj.output?.choices?.[0]?.message?.content || '';
+          result += chunk;
+        } catch {}
+      }
+    }
+    if (debug) console.log('QTDEBUG: background translation completed');
+    return { text: result };
+  } catch (err) {
+    clearTimeout(timer);
+    console.error('QTERROR: background translation error', err);
+    return { error: err.message };
+  }
+}
+
+chrome.runtime.onMessage.addListener((msg, sender) => {
+  if (msg.action === 'translate') {
+    return handleTranslate(msg.opts);
   }
 });

--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,7 @@ const defaultCfg = {
   autoTranslate: false,
   requestLimit: 60,
   tokenLimit: 100000,
+  debug: false,
 };
 
 function qwenLoadConfig() {

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -33,6 +33,7 @@ async function translateNode(node) {
   const text = node.textContent.trim();
   if (!text) return;
   try {
+    if (currentConfig.debug) console.log('QTDEBUG: translating node', text.slice(0, 20));
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 10000);
     const { text: translated } = await window.qwenTranslate({
@@ -43,13 +44,14 @@ async function translateNode(node) {
       source: currentConfig.sourceLanguage,
       target: currentConfig.targetLanguage,
       signal: controller.signal,
+      debug: currentConfig.debug,
     });
     clearTimeout(timeout);
     node.textContent = translated;
     mark(node);
   } catch (e) {
     showError(`${e.message}. See console for details.`);
-    console.error('Translation error:', e);
+    console.error('QTERROR: translation error', e);
   }
 }
 
@@ -86,9 +88,10 @@ function observe() {
 async function start() {
   currentConfig = await window.qwenLoadConfig();
   if (!currentConfig.apiKey) {
-    console.warn('Qwen Translator: API key not configured.');
+    console.warn('QTWARN: API key not configured.');
     return;
   }
+  if (currentConfig.debug) console.log('QTDEBUG: starting automatic translation');
   scan();
   observe();
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.0",
+  "version": "1.2",
   "permissions": ["storage", "activeTab", "tabs", "scripting"],
   "host_permissions": [
     "https://dashscope-intl.aliyuncs.com/*"

--- a/src/popup.html
+++ b/src/popup.html
@@ -20,9 +20,11 @@
   <label>Requests per minute <input type="number" id="requestLimit"></label>
   <label>Tokens per minute <input type="number" id="tokenLimit"></label>
   <label><input type="checkbox" id="auto"> Translate automatically</label>
+  <label><input type="checkbox" id="debug"> Debug logging</label>
   <button id="save">Save</button>
   <button id="test">Test Settings</button>
   <div id="status"></div>
+  <div id="version" style="font-size:11px;color:#777;margin-top:4px"></div>
   <script src="throttle.js"></script>
   <script src="translator.js"></script>
   <script src="config.js"></script>


### PR DESCRIPTION
## Summary
- add timeouts to popup testing and log results
- improve debug logs in translator and content scripts
- refactor background listener to return a promise
- bump version to 1.2

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a81865c488323914f6fe7142d88eb