### PR TITLE
Improve debug logging

### DIFF
--- a/cli/translate.js
+++ b/cli/translate.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const readline = require('readline');
-const fetch = require('cross-fetch');
+const fetch = globalThis.fetch || require('cross-fetch');
 const { runWithRateLimit, approxTokens, configure } = require('../src/throttle');
 
 function withSlash(url) {

--- a/src/popup.js
+++ b/src/popup.js
@@ -62,21 +62,21 @@ document.getElementById('save').addEventListener('click', () => {
 
 document.getElementById('test').addEventListener('click', async () => {
   status.textContent = 'Testing...';
-  console.log('QTDEBUG: starting configuration test');
+  const cfg = {
+    endpoint: endpointInput.value.trim(),
+    apiKey: apiKeyInput.value.trim(),
+    model: modelInput.value.trim(),
+    source: sourceSelect.value,
+    target: targetSelect.value,
+    debug: debugCheckbox.checked,
+  };
+  console.log('QTDEBUG: starting configuration test', cfg);
   const timer = setTimeout(() => {
     console.error('QTERROR: configuration test timed out');
     status.textContent = 'Error: timeout';
   }, 15000);
   try {
-    await window.qwenTranslate({
-      endpoint: endpointInput.value.trim(),
-      apiKey: apiKeyInput.value.trim(),
-      model: modelInput.value.trim(),
-      source: sourceSelect.value,
-      text: 'hello',
-      target: targetSelect.value,
-      debug: debugCheckbox.checked,
-    });
+    await window.qwenTranslate({ ...cfg, text: 'hello' });
     status.textContent = 'Configuration OK';
     console.log('QTDEBUG: configuration test successful');
   } catch (e) {

--- a/src/throttle.js
+++ b/src/throttle.js
@@ -54,6 +54,7 @@ async function runWithRetry(fn, text, attempts = 3, debug = false) {
   let wait = 500;
   for (let i = 0; i < attempts; i++) {
     try {
+      if (debug) console.log('QTDEBUG: attempt', i + 1);
       return await runWithRateLimit(fn, tokens);
     } catch (err) {
       if (!err.retryable || i === attempts - 1) throw err;

--- a/src/translator.js
+++ b/src/translator.js
@@ -4,7 +4,8 @@ var runWithRetry;
 var approxTokens;
 
 if (typeof window === 'undefined') {
-  fetchFn = require('cross-fetch');
+  // Node 18+ provides a global fetch implementation
+  fetchFn = typeof fetch !== 'undefined' ? fetch : require('cross-fetch');
   ({ runWithRateLimit, runWithRetry, approxTokens } = require('./throttle'));
 } else {
   if (window.qwenThrottle) {
@@ -26,7 +27,10 @@ function withSlash(url) {
 
 async function doFetch({ endpoint, apiKey, model, text, source, target, signal, debug }) {
   const url = `${withSlash(endpoint)}services/aigc/text-generation/generation`;
-  if (debug) console.log('QTDEBUG: sending translation request to', url);
+  if (debug) {
+    console.log('QTDEBUG: sending translation request to', url);
+    console.log('QTDEBUG: request params', { model, source, target, text });
+  }
   const body = {
     model,
     input: { messages: [{ role: 'user', content: text }] },
@@ -46,6 +50,7 @@ async function doFetch({ endpoint, apiKey, model, text, source, target, signal, 
       body: JSON.stringify(body),
       signal,
     });
+    if (debug) console.log('QTDEBUG: response status', resp.status);
   } catch (e) {
     e.retryable = true;
     throw e;
@@ -55,10 +60,12 @@ async function doFetch({ endpoint, apiKey, model, text, source, target, signal, 
       .json()
       .catch(() => ({ message: resp.statusText }));
     const error = new Error(`HTTP ${resp.status}: ${err.message || 'Translation failed'}`);
+    if (debug) console.log('QTDEBUG: HTTP error response', error.message);
     if (resp.status >= 500) error.retryable = true;
     throw error;
   }
   if (!resp.body || typeof resp.body.getReader !== 'function') {
+    if (debug) console.log('QTDEBUG: received non-streaming response');
     const data = await resp.json();
     const text =
       data.output?.text ||
@@ -68,6 +75,8 @@ async function doFetch({ endpoint, apiKey, model, text, source, target, signal, 
     }
     return { text };
   }
+
+  if (debug) console.log('QTDEBUG: reading streaming response');
 
   const reader = resp.body.getReader();
   const decoder = new TextDecoder();
@@ -93,6 +102,7 @@ async function doFetch({ endpoint, apiKey, model, text, source, target, signal, 
           obj.output?.text ||
           obj.output?.choices?.[0]?.message?.content || '';
         result += chunk;
+        if (debug && chunk) console.log('QTDEBUG: chunk received', chunk);
       } catch {}
     }
   }
@@ -127,7 +137,10 @@ async function qwenTranslate({ endpoint, apiKey, model, text, source, target, si
       debug
     );
     cache.set(cacheKey, data);
-    if (debug) console.log('QTDEBUG: translation successful');
+    if (debug) {
+      console.log('QTDEBUG: translation successful');
+      console.log('QTDEBUG: final text', data.text);
+    }
     return data;
   } catch (e) {
     console.error('QTERROR: translation request failed', e);


### PR DESCRIPTION
## Summary
- improve CLI compatibility with Node 18+ by falling back to global `fetch`
- add detailed debug output in popup's configuration test
- enhance retry logging
- extend translator debug logs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ab28fba4c8323ac83178faac808f0