### PR TITLE
Improve debug logging

### DIFF
--- a/cli/translate.js
+++ b/cli/translate.js
@@ -1,31 +1,38 @@
 #!/usr/bin/env node
 
 const readline = require('readline');
-const fetch = require('cross-fetch');
+const fetch = globalThis.fetch || require('cross-fetch');
 const { runWithRateLimit, approxTokens, configure } = require('../src/throttle');
 
 function withSlash(url) {
   return url.endsWith('/') ? url : `${url}/`;
 }
 
-async function translateStream({ endpoint, apiKey, model, text, source, target }, onData) {
+async function translateStream({ endpoint, apiKey, model, text, source, target, debug }, onData) {
   const url = `${withSlash(endpoint)}services/aigc/text-generation/generation`;
   const body = {
     model,
     input: { messages: [{ role: 'user', content: text }] },
     parameters: { translation_options: { source_lang: source, target_lang: target } },
   };
+  if (debug) {
+    console.log('QTDEBUG: sending CLI request to', url);
+    console.log('QTDEBUG: request params', { model, source, target, text });
+  }
   const resp = await runWithRateLimit(
     () => fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: apiKey,
+        'X-DashScope-SSE': 'enable',
       },
       body: JSON.stringify(body),
     }),
     approxTokens(text)
   );
+
+  if (debug) console.log('QTDEBUG: response status', resp.status);
 
   if (!resp.ok) {
     const err = await resp.json().catch(() => ({ message: resp.statusText }));
@@ -33,6 +40,7 @@ async function translateStream({ endpoint, apiKey, model, text, source, target }
   }
 
   if (!resp.body || typeof resp.body.getReader !== 'function') {
+    if (debug) console.log('QTDEBUG: received non-streaming response');
     const data = await resp.json();
     if (data.output && data.output.text) onData(data.output.text);
     return;
@@ -57,7 +65,11 @@ async function translateStream({ endpoint, apiKey, model, text, source, target }
       }
       try {
         const obj = JSON.parse(data);
-        if (obj.output && obj.output.text) onData(obj.output.text);
+        const chunk = obj.output && obj.output.text;
+        if (chunk) {
+          if (debug) console.log('QTDEBUG: chunk received', chunk);
+          onData(chunk);
+        }
       } catch {}
     }
   }
@@ -75,6 +87,7 @@ function parseArgs() {
     else if (a === '-t' || a === '--target') opts.target = args[++i];
     else if (a === '--requests') opts.requestLimit = parseInt(args[++i], 10);
     else if (a === '--tokens') opts.tokenLimit = parseInt(args[++i], 10);
+    else if (a === '-d' || a === '--debug') opts.debug = true;
     else if (a === '-h' || a === '--help') opts.help = true;
   }
   return opts;
@@ -86,12 +99,21 @@ async function main() {
   const opts = parseArgs();
 
   if (opts.help || !opts.apiKey || !opts.source || !opts.target) {
-    console.log('Usage: node translate.js -k <apiKey> [-e endpoint] [-m model] [-\-requests N] [-\-tokens M] -s <source> -t <target>');
+    console.log('Usage: node translate.js -k <apiKey> [-e endpoint] [-m model] [-\-requests N] [-\-tokens M] [-d] -s <source> -t <target>');
     process.exit(opts.help ? 0 : 1);
   }
 
   opts.endpoint = opts.endpoint || DEFAULT_ENDPOINT;
   opts.model = opts.model || DEFAULT_MODEL;
+
+  if (opts.debug) {
+    console.log('QTDEBUG: starting CLI with options', {
+      endpoint: opts.endpoint,
+      model: opts.model,
+      source: opts.source,
+      target: opts.target,
+    });
+  }
 
   configure({
     requestLimit: opts.requestLimit || 60,
@@ -105,7 +127,10 @@ async function main() {
     line = line.trim();
     if (!line) { rl.prompt(); return; }
     try {
-      await translateStream({ ...opts, text: line }, chunk => process.stdout.write(chunk));
+      await translateStream({ ...opts, text: line, debug: opts.debug }, chunk => {
+        if (opts.debug) console.log('QTDEBUG: chunk received', chunk);
+        process.stdout.write(chunk);
+      });
       process.stdout.write('\n');
     } catch (err) {
       console.error(err.stack || err.toString());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.3",
+  "version": "1.3.1",
   "permissions": ["storage", "activeTab", "tabs", "scripting"],
   "host_permissions": [
     "https://dashscope-intl.aliyuncs.com/*"

--- a/src/popup.js
+++ b/src/popup.js
@@ -62,21 +62,21 @@ document.getElementById('save').addEventListener('click', () => {
 
 document.getElementById('test').addEventListener('click', async () => {
   status.textContent = 'Testing...';
-  console.log('QTDEBUG: starting configuration test');
+  const cfg = {
+    endpoint: endpointInput.value.trim(),
+    apiKey: apiKeyInput.value.trim(),
+    model: modelInput.value.trim(),
+    source: sourceSelect.value,
+    target: targetSelect.value,
+    debug: true,
+  };
+  console.log('QTDEBUG: starting configuration test', cfg);
   const timer = setTimeout(() => {
     console.error('QTERROR: configuration test timed out');
     status.textContent = 'Error: timeout';
   }, 15000);
   try {
-    await window.qwenTranslate({
-      endpoint: endpointInput.value.trim(),
-      apiKey: apiKeyInput.value.trim(),
-      model: modelInput.value.trim(),
-      source: sourceSelect.value,
-      text: 'hello',
-      target: targetSelect.value,
-      debug: debugCheckbox.checked,
-    });
+    await window.qwenTranslate({ ...cfg, text: 'hello' });
     status.textContent = 'Configuration OK';
     console.log('QTDEBUG: configuration test successful');
   } catch (e) {

--- a/src/throttle.js
+++ b/src/throttle.js
@@ -54,6 +54,7 @@ async function runWithRetry(fn, text, attempts = 3, debug = false) {
   let wait = 500;
   for (let i = 0; i < attempts; i++) {
     try {
+      if (debug) console.log('QTDEBUG: attempt', i + 1);
       return await runWithRateLimit(fn, tokens);
     } catch (err) {
       if (!err.retryable || i === attempts - 1) throw err;

--- a/src/translator.js
+++ b/src/translator.js
@@ -4,7 +4,8 @@ var runWithRetry;
 var approxTokens;
 
 if (typeof window === 'undefined') {
-  fetchFn = require('cross-fetch');
+  // Node 18+ provides a global fetch implementation
+  fetchFn = typeof fetch !== 'undefined' ? fetch : require('cross-fetch');
   ({ runWithRateLimit, runWithRetry, approxTokens } = require('./throttle'));
 } else {
   if (window.qwenThrottle) {
@@ -26,7 +27,10 @@ function withSlash(url) {
 
 async function doFetch({ endpoint, apiKey, model, text, source, target, signal, debug }) {
   const url = `${withSlash(endpoint)}services/aigc/text-generation/generation`;
-  if (debug) console.log('QTDEBUG: sending translation request to', url);
+  if (debug) {
+    console.log('QTDEBUG: sending translation request to', url);
+    console.log('QTDEBUG: request params', { model, source, target, text });
+  }
   const body = {
     model,
     input: { messages: [{ role: 'user', content: text }] },
@@ -41,11 +45,12 @@ async function doFetch({ endpoint, apiKey, model, text, source, target, signal, 
       headers: {
         'Content-Type': 'application/json',
         Authorization: apiKey,
-        ...(typeof window !== 'undefined' ? { 'X-DashScope-SSE': 'enable' } : {}),
+        'X-DashScope-SSE': 'enable',
       },
       body: JSON.stringify(body),
       signal,
     });
+    if (debug) console.log('QTDEBUG: response status', resp.status);
   } catch (e) {
     e.retryable = true;
     throw e;
@@ -55,10 +60,12 @@ async function doFetch({ endpoint, apiKey, model, text, source, target, signal, 
       .json()
       .catch(() => ({ message: resp.statusText }));
     const error = new Error(`HTTP ${resp.status}: ${err.message || 'Translation failed'}`);
+    if (debug) console.log('QTDEBUG: HTTP error response', error.message);
     if (resp.status >= 500) error.retryable = true;
     throw error;
   }
   if (!resp.body || typeof resp.body.getReader !== 'function') {
+    if (debug) console.log('QTDEBUG: received non-streaming response');
     const data = await resp.json();
     const text =
       data.output?.text ||
@@ -68,6 +75,8 @@ async function doFetch({ endpoint, apiKey, model, text, source, target, signal, 
     }
     return { text };
   }
+
+  if (debug) console.log('QTDEBUG: reading streaming response');
 
   const reader = resp.body.getReader();
   const decoder = new TextDecoder();
@@ -93,6 +102,7 @@ async function doFetch({ endpoint, apiKey, model, text, source, target, signal, 
           obj.output?.text ||
           obj.output?.choices?.[0]?.message?.content || '';
         result += chunk;
+        if (debug && chunk) console.log('QTDEBUG: chunk received', chunk);
       } catch {}
     }
   }
@@ -100,6 +110,16 @@ async function doFetch({ endpoint, apiKey, model, text, source, target, signal, 
 }
 
 async function qwenTranslate({ endpoint, apiKey, model, text, source, target, signal, debug = false }) {
+  if (debug) {
+    console.log('QTDEBUG: qwenTranslate called with', {
+      endpoint,
+      apiKeySet: Boolean(apiKey),
+      model,
+      source,
+      target,
+      text: text && text.slice ? text.slice(0, 20) + (text.length > 20 ? '...' : '') : text,
+    });
+  }
   const cacheKey = `${source}:${target}:${text}`;
   if (cache.has(cacheKey)) {
     return cache.get(cacheKey);
@@ -127,7 +147,10 @@ async function qwenTranslate({ endpoint, apiKey, model, text, source, target, si
       debug
     );
     cache.set(cacheKey, data);
-    if (debug) console.log('QTDEBUG: translation successful');
+    if (debug) {
+      console.log('QTDEBUG: translation successful');
+      console.log('QTDEBUG: final text', data.text);
+    }
     return data;
   } catch (e) {
     console.error('QTERROR: translation request failed', e);


### PR DESCRIPTION
## Summary
- increase version number to 1.3.1
- always enable debug mode for config tests in popup
- log request details and streaming chunks in the CLI
- add start-of-call debug log and always send SSE header

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ab28fba4c8323ac83178faac808f0