### PR TITLE
Improve diagnostics with service worker ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This Chrome extension translates the content of the active tab using Alibaba Clo
 4. Choose "Load unpacked" and select the folder containing the extension files.
    The extension requests the "tabs" permission so the popup can send
    messages to the active tab for translation.
+   If Chrome reports **Service worker registration failed. Status code: 15**,
+   ensure the selected folder contains `manifest.json`, `background.js` and the
+   other files from the `src` directory. Loading the repository root without the
+   bundled files will cause the worker to fail.
 
 ## Uninstallation
 Remove the extension from the browser's extension management page.
@@ -26,11 +30,12 @@ Click **Test Settings** in the popup to run a short diagnostic. The extension pe
 1. Connect to the configured API endpoint
 2. Send an OPTIONS preflight request to the translation URL
 3. Perform a direct non-stream translation
-4. Perform the same translation via the background service worker
-5. Send a streaming translation request
-6. Read the contents of the active tab
-7. Translate a short string inside the active tab
-8. Verify that extension settings can be saved
+4. Verify that the background service worker responds
+5. Perform the same translation via the background service worker
+6. Send a streaming translation request
+7. Read the contents of the active tab
+8. Translate a short string inside the active tab
+9. Verify that extension settings can be saved
 Each step displays a pass or fail result and honours the debug logging preference.
 The active tab check may fail on browser-internal pages (such as the Chrome Web Store or settings). Open a regular web page before running the test.
 The final end-to-end tab translation aborts after about 10 seconds if no response is received.
@@ -48,6 +53,7 @@ Both model refreshes and translation requests write trace logs to the browser co
 If the **Test Settings** button reports a timeout, the network request may be blocked by Content Security Policy or CORS restrictions. The extension automatically falls back to `XMLHttpRequest` when `fetch` fails, but some environments may still prevent the call entirely.
 If the **Read active tab** check fails, make sure the currently focused tab is a normal web page; the extension cannot access Chrome or extension pages.
 If the tab translation step fails, the page may block script execution or DOM updates.
+Some sites impose strict Content Security Policies that prevent the test element from executing or restrict network requests. Open a simple page such as `https://example.com` before running the tests. Console errors from third-party resources do not affect the translation check.
 
 ## Development
 Run the unit tests with:

--- a/src/background.js
+++ b/src/background.js
@@ -1,6 +1,4 @@
 importScripts('throttle.js', 'translator.js');
-const { configure } = self.qwenThrottle;
-const { qwenTranslate } = self;
 
 chrome.runtime.onInstalled.addListener(() => {
   console.log('Qwen Translator installed');
@@ -14,13 +12,17 @@ async function handleTranslate(opts) {
   const cfg = await new Promise(resolve =>
     chrome.storage.sync.get({ requestLimit: 60, tokenLimit: 100000 }, resolve)
   );
-  configure({ requestLimit: cfg.requestLimit, tokenLimit: cfg.tokenLimit, windowMs: 60000 });
+  self.qwenThrottle.configure({
+    requestLimit: cfg.requestLimit,
+    tokenLimit: cfg.tokenLimit,
+    windowMs: 60000,
+  });
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 20000);
 
   try {
-    const result = await qwenTranslate({
+    const result = await self.qwenTranslate({
       endpoint: ep,
       apiKey,
       model,
@@ -41,8 +43,13 @@ async function handleTranslate(opts) {
   }
 }
 
-chrome.runtime.onMessage.addListener((msg, sender) => {
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.action === 'translate') {
     return handleTranslate(msg.opts);
+  }
+  if (msg.action === 'ping') {
+    if (msg.debug) console.log('QTDEBUG: ping received');
+    sendResponse({ ok: true });
+    return true;
   }
 });

--- a/src/popup.js
+++ b/src/popup.js
@@ -124,6 +124,19 @@ document.getElementById('test').addEventListener('click', async () => {
     if (!res.text) throw new Error('empty response');
   })) && allOk;
 
+  allOk = (await run('Background ping', async () => {
+    const resp = await new Promise((resolve, reject) => {
+      chrome.runtime.sendMessage({ action: 'ping', debug: cfg.debug }, res => {
+        if (chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message));
+        } else {
+          resolve(res);
+        }
+      });
+    });
+    if (!resp || !resp.ok) throw new Error('no response');
+  })) && allOk;
+
   allOk = (await run('Background translation', async () => {
     const res = await window.qwenTranslate({ ...cfg, text: 'hello', stream: false });
     if (!res.text) throw new Error('empty response');


### PR DESCRIPTION
## Summary
- add `ping` handler in background script
- call `Background ping` during Test Settings
- document new diagnostic step
- fix duplicate declarations that broke the service worker

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688cd4fef6048323ad6171f665bd7fa7