### PR TITLE
Fix undefined tab translation response

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This Chrome extension translates the content of the active tab using Alibaba Clo
 4. Choose "Load unpacked" and select the folder containing the extension files.
    The extension requests the "tabs" permission so the popup can send
    messages to the active tab for translation.
+   If Chrome reports **Service worker registration failed. Status code: 15**,
+   ensure the selected folder contains `manifest.json`, `background.js` and the
+   other files from the `src` directory. Loading the repository root without the
+   bundled files will cause the worker to fail.
 
 ## Uninstallation
 Remove the extension from the browser's extension management page.
@@ -26,28 +30,37 @@ Click **Test Settings** in the popup to run a short diagnostic. The extension pe
 1. Connect to the configured API endpoint
 2. Send an OPTIONS preflight request to the translation URL
 3. Perform a direct non-stream translation
-4. Perform the same translation via the background service worker
-5. Send a streaming translation request
-6. Read the contents of the active tab
-7. Translate a short string inside the active tab
-8. Verify that extension settings can be saved
+4. Verify that the background service worker responds
+5. Perform the same translation via the background service worker
+6. Send a streaming translation request
+7. Read the contents of the active tab
+8. Translate a short string inside the active tab
+9. Verify that extension settings can be saved
 Each step displays a pass or fail result and honours the debug logging preference.
 The active tab check may fail on browser-internal pages (such as the Chrome Web Store or settings). Open a regular web page before running the test.
 The final end-to-end tab translation aborts after about 10 seconds if no response is received.
+The sample phrase is chosen based on the configured source language so the translated text differs from the original.
 
 ## Usage
-Click the extension icon and choose **Translate Page**. If automatic translation is enabled the page will be translated on load. Translations apply to dynamically added content.
-If translation fails, an error message appears at the bottom-right of the page. Translations are cached for the current session to minimise API calls.
+Click the extension icon and choose **Translate Page**. If automatic translation is enabled the page will be translated on load. Translations apply to dynamically added content as well as embedded frames or third-party widgets whenever the browser grants access. If translation fails the affected text is kept in a queue and retried until the API succeeds. When the translated text matches the original the node is marked as untranslatable and skipped. Translations are cached for the current session to minimise API calls.
+Identical strings are translated only once and reused across matching nodes, and hidden or off-screen elements are ignored so tokens are spent only on visible text.
+Translated nodes keep their original leading and trailing whitespace and the navigation menu is processed before the rest of the page so key controls appear quickly. While translations are running the extension's toolbar icon shows an activity badge and a temporary status box in the bottom-right corner of the page reports current work or errors. The box disappears automatically when the extension is idle.
 
 ### Rate Limiting
 The extension and CLI queue translation requests to stay within the provider limits.
+The background worker maintains a single queue so multiple page nodes are translated sequentially rather than all at once, preventing bursts that would trigger HTTP 429 errors. Nodes are batched into combined translation requests to reduce the overall query count. If the provider still returns a 429 response the request is retried automatically.
 You can adjust the limits under **Requests per minute** and **Tokens per minute** in the extension popup or via `--requests` and `--tokens` on the CLI. Defaults are 60 requests and 100,000 tokens every 60 seconds.
+The popup displays live usage for the last minute and colour-coded bars turn yellow or red as limits are approached. Usage statistics refresh every second and also show total requests, total tokens and the current queue length.
 
 ### Troubleshooting
 Both model refreshes and translation requests write trace logs to the browser console. Copy any on-page error and check the console for a matching entry to diagnose problems.
 If the **Test Settings** button reports a timeout, the network request may be blocked by Content Security Policy or CORS restrictions. The extension automatically falls back to `XMLHttpRequest` when `fetch` fails, but some environments may still prevent the call entirely.
 If the **Read active tab** check fails, make sure the currently focused tab is a normal web page; the extension cannot access Chrome or extension pages.
 If the tab translation step fails, the page may block script execution or DOM updates.
+Some sites impose strict Content Security Policies that prevent the test element from executing or restrict network requests. Open a simple page such as `https://example.com` before running the tests. Console errors from third-party resources do not affect the translation check.
+Enable **Debug logging** in the popup to see details about the active tab and any error stack returned by the content script.
+If a translated page appears unchanged, verify that the source and target languages are configured correctly. With debug logging enabled the console warns when the translation result matches the original text.
+Shadow DOM content and same-origin iframes are scanned and translated automatically. Cross-origin frames may be translated when host permissions allow access, otherwise they are skipped.
 
 ## Development
 Run the unit tests with:

--- a/src/background.js
+++ b/src/background.js
@@ -1,26 +1,54 @@
 importScripts('throttle.js', 'translator.js');
-const { configure } = self.qwenThrottle;
-const { qwenTranslate } = self;
 
 chrome.runtime.onInstalled.addListener(() => {
   console.log('Qwen Translator installed');
 });
+
+let throttleReady;
+let activeTranslations = 0;
+
+function updateBadge() {
+  if (activeTranslations > 0) {
+    chrome.action.setBadgeText({ text: '...' });
+    chrome.action.setBadgeBackgroundColor({ color: '#0d6efd' });
+  } else {
+    chrome.action.setBadgeText({ text: '' });
+  }
+}
+updateBadge();
+function ensureThrottle() {
+  if (!throttleReady) {
+    throttleReady = new Promise(resolve => {
+      chrome.storage.sync.get(
+        { requestLimit: 60, tokenLimit: 100000 },
+        cfg => {
+          self.qwenThrottle.configure({
+            requestLimit: cfg.requestLimit,
+            tokenLimit: cfg.tokenLimit,
+            windowMs: 60000,
+          });
+          resolve();
+        }
+      );
+    });
+  }
+  return throttleReady;
+}
 
 async function handleTranslate(opts) {
   const { endpoint, apiKey, model, text, source, target, debug } = opts;
   const ep = endpoint.endsWith('/') ? endpoint : `${endpoint}/`;
   if (debug) console.log('QTDEBUG: background translating via', ep);
 
-  const cfg = await new Promise(resolve =>
-    chrome.storage.sync.get({ requestLimit: 60, tokenLimit: 100000 }, resolve)
-  );
-  configure({ requestLimit: cfg.requestLimit, tokenLimit: cfg.tokenLimit, windowMs: 60000 });
+  await ensureThrottle();
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 20000);
+  activeTranslations++;
+  updateBadge();
 
   try {
-    const result = await qwenTranslate({
+    const result = await self.qwenTranslate({
       endpoint: ep,
       apiKey,
       model,
@@ -38,11 +66,28 @@ async function handleTranslate(opts) {
     return { error: err.message };
   } finally {
     clearTimeout(timeout);
+    activeTranslations--;
+    updateBadge();
   }
 }
 
-chrome.runtime.onMessage.addListener((msg, sender) => {
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.action === 'translate') {
-    return handleTranslate(msg.opts);
+    handleTranslate(msg.opts)
+      .then(sendResponse)
+      .catch(err => sendResponse({ error: err.message }));
+    return true;
+  }
+  if (msg.action === 'ping') {
+    if (msg.debug) console.log('QTDEBUG: ping received');
+    sendResponse({ ok: true });
+    return true;
+  }
+  if (msg.action === 'usage') {
+    ensureThrottle().then(() => {
+      const stats = self.qwenThrottle.getUsage();
+      sendResponse(stats);
+    });
+    return true;
   }
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,6 +5,7 @@
   "version": "1.3.1",
   "permissions": ["storage", "activeTab", "tabs", "scripting"],
   "host_permissions": [
+    "<all_urls>",
     "https://dashscope-intl.aliyuncs.com/*"
   ],
   "background": {
@@ -24,7 +25,8 @@
     {
       "matches": ["<all_urls>"],
       "js": ["config.js", "throttle.js", "translator.js", "contentScript.js"],
-      "run_at": "document_idle"
+      "run_at": "document_idle",
+      "all_frames": true
     }
   ]
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -8,6 +8,9 @@
     input[type=text], select { width:100%; box-sizing:border-box; margin-top:2px; }
     button { width: 100%; margin-top:6px; padding:6px; }
     #status { margin-top:5px; font-size:12px; color:#555; min-height:16px; }
+    #usage { margin-top:6px; font-size:11px; }
+    .bar { height:6px; background:#ddd; margin-top:2px; }
+    .bar > div { height:100%; width:0%; background:green; }
   </style>
 </head>
 <body>
@@ -21,6 +24,15 @@
   <label>Tokens per minute <input type="number" id="tokenLimit"></label>
   <label><input type="checkbox" id="auto"> Translate automatically</label>
   <label><input type="checkbox" id="debug"> Debug logging</label>
+  <div id="usage">
+    <div>Requests <span id="reqCount">0/0</span></div>
+    <div class="bar"><div id="reqBar"></div></div>
+    <div>Tokens <span id="tokenCount">0/0</span></div>
+    <div class="bar"><div id="tokenBar"></div></div>
+    <div>Total Requests <span id="totalReq">0</span></div>
+    <div>Total Tokens <span id="totalTok">0</span></div>
+    <div>Queue <span id="queueLen">0</span></div>
+  </div>
   <button id="save">Save</button>
   <button id="test">Test Settings</button>
   <div id="status"></div>

--- a/src/throttle.js
+++ b/src/throttle.js
@@ -1,22 +1,29 @@
-const queue = [];
-let config = {
-  requestLimit: 60,
-  tokenLimit: 100000,
-  windowMs: 60000,
-};
-let availableRequests = config.requestLimit;
-let availableTokens = config.tokenLimit;
-let interval = setInterval(() => {
-  availableRequests = config.requestLimit;
-  availableTokens = config.tokenLimit;
-  processQueue();
-}, config.windowMs);
+;(function (root) {
+  if (root.qwenThrottle) return
+
+  const queue = []
+  let config = {
+    requestLimit: 60,
+    tokenLimit: 100000,
+    windowMs: 60000,
+  }
+  let availableRequests = config.requestLimit
+  let availableTokens = config.tokenLimit
+  const requestTimes = []
+  const tokenTimes = []
+  let totalRequests = 0
+  let totalTokens = 0
+  let interval = setInterval(() => {
+    availableRequests = config.requestLimit
+    availableTokens = config.tokenLimit
+    processQueue()
+  }, config.windowMs)
 
 function approxTokens(text) {
   return Math.max(1, Math.ceil(text.length / 4));
 }
 
-function configure(opts = {}) {
+function throttleConfigure(opts = {}) {
   Object.assign(config, opts);
   availableRequests = config.requestLimit;
   availableTokens = config.tokenLimit;
@@ -28,11 +35,26 @@ function configure(opts = {}) {
   }, config.windowMs);
 }
 
+function recordUsage(tokens) {
+  const now = Date.now();
+  requestTimes.push(now);
+  tokenTimes.push({ time: now, tokens });
+  totalRequests++
+  totalTokens += tokens
+  prune(now);
+}
+
+function prune(now = Date.now()) {
+  while (requestTimes.length && now - requestTimes[0] > config.windowMs) requestTimes.shift();
+  while (tokenTimes.length && now - tokenTimes[0].time > config.windowMs) tokenTimes.shift();
+}
+
 function processQueue() {
   while (queue.length && availableRequests > 0 && availableTokens >= queue[0].tokens) {
     const item = queue.shift();
     availableRequests--;
     availableTokens -= item.tokens;
+    recordUsage(item.tokens);
     item.fn().then(item.resolve, item.reject);
   }
 }
@@ -65,12 +87,39 @@ async function runWithRetry(fn, text, attempts = 3, debug = false) {
   }
 }
 
-if (typeof module !== 'undefined') {
-  module.exports = { runWithRateLimit, runWithRetry, configure, approxTokens };
+function getUsage() {
+  prune();
+  const tokensUsed = tokenTimes.reduce((s, t) => s + t.tokens, 0);
+  return {
+    requests: requestTimes.length,
+    tokens: tokensUsed,
+    requestLimit: config.requestLimit,
+    tokenLimit: config.tokenLimit,
+    totalRequests,
+    totalTokens,
+    queue: queue.length,
+  };
 }
 
-if (typeof window !== 'undefined') {
-  window.qwenThrottle = { runWithRateLimit, runWithRetry, configure, approxTokens };
-} else if (typeof self !== 'undefined') {
-  self.qwenThrottle = { runWithRateLimit, runWithRetry, configure, approxTokens };
-}
+  if (typeof module !== 'undefined') {
+    module.exports = { runWithRateLimit, runWithRetry, configure: throttleConfigure, approxTokens, getUsage }
+  }
+
+  if (typeof window !== 'undefined') {
+    root.qwenThrottle = {
+      runWithRateLimit,
+      runWithRetry,
+      configure: throttleConfigure,
+      approxTokens,
+      getUsage,
+    }
+  } else if (typeof self !== 'undefined') {
+    root.qwenThrottle = {
+      runWithRateLimit,
+      runWithRetry,
+      configure: throttleConfigure,
+      approxTokens,
+      getUsage,
+    }
+  }
+})(typeof window !== 'undefined' ? window : typeof self !== 'undefined' ? self : globalThis)

--- a/src/translator.js
+++ b/src/translator.js
@@ -112,15 +112,15 @@ async function doFetch({ endpoint, apiKey, model, text, source, target, signal, 
       throw e;
     }
   }
-  if (!resp.ok) {
-    const err = await resp
-      .json()
-      .catch(() => ({ message: resp.statusText }));
-    const error = new Error(`HTTP ${resp.status}: ${err.message || 'Translation failed'}`);
-    if (debug) console.log('QTDEBUG: HTTP error response', error.message);
-    if (resp.status >= 500) error.retryable = true;
-    throw error;
-  }
+    if (!resp.ok) {
+      const err = await resp
+        .json()
+        .catch(() => ({ message: resp.statusText }));
+      const error = new Error(`HTTP ${resp.status}: ${err.message || 'Translation failed'}`);
+      if (debug) console.log('QTDEBUG: HTTP error response', error.message);
+      if (resp.status >= 500 || resp.status === 429) error.retryable = true;
+      throw error;
+    }
   if (!stream || !resp.body || typeof resp.body.getReader !== 'function') {
     if (debug) console.log('QTDEBUG: received non-streaming response');
     const data = await resp.json();
@@ -184,13 +184,38 @@ async function qwenTranslate({ endpoint, apiKey, model, text, source, target, si
     return cache.get(cacheKey);
   }
 
-  if (!noProxy && typeof window !== 'undefined' && typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.sendMessage) {
+  if (
+    !noProxy &&
+    typeof window !== 'undefined' &&
+    typeof chrome !== 'undefined' &&
+    chrome.runtime &&
+    chrome.runtime.sendMessage
+  ) {
     const ep = withSlash(endpoint);
     if (debug) console.log('QTDEBUG: requesting translation via background script');
-    const result = await chrome.runtime
-      .sendMessage({ action: 'translate', opts: { endpoint: ep, apiKey, model, text, source, target, debug } })
-      .catch(err => { throw new Error(err.message || err); });
-    if (result && result.error) {
+    const result = await new Promise((resolve, reject) => {
+      try {
+        chrome.runtime.sendMessage(
+          {
+            action: 'translate',
+            opts: { endpoint: ep, apiKey, model, text, source, target, debug },
+          },
+          res => {
+            if (chrome.runtime.lastError) {
+              reject(new Error(chrome.runtime.lastError.message));
+            } else {
+              resolve(res);
+            }
+          }
+        );
+      } catch (err) {
+        reject(err);
+      }
+    });
+    if (!result) {
+      throw new Error('No response from background');
+    }
+    if (result.error) {
       throw new Error(result.error);
     }
     if (debug) console.log('QTDEBUG: background response received');
@@ -252,19 +277,50 @@ async function qwenTranslateStream({ endpoint, apiKey, model, text, source, targ
     throw e;
   }
 }
+
+async function qwenTranslateBatch({ texts = [], ...opts }) {
+  const results = new Array(texts.length);
+  const indexMap = new Map();
+  texts.forEach((t, i) => {
+    const key = `${opts.source}:${opts.target}:${t}`;
+    if (cache.has(key)) {
+      results[i] = cache.get(key).text;
+    } else {
+      if (!indexMap.has(t)) indexMap.set(t, []);
+      indexMap.get(t).push(i);
+    }
+  });
+  const unique = Array.from(indexMap.keys());
+  if (unique.length) {
+    const joined = unique.join('\n');
+    const res = await qwenTranslate({ ...opts, text: joined });
+    const translated = res.text.split('\n');
+    translated.forEach((tr, idx) => {
+      const orig = unique[idx];
+      const key = `${opts.source}:${opts.target}:${orig}`;
+      cache.set(key, { text: tr });
+      indexMap.get(orig).forEach(i => {
+        results[i] = tr;
+      });
+    });
+  }
+  return { texts: results };
+}
 function qwenClearCache() {
   cache.clear();
 }
 if (typeof window !== 'undefined') {
   window.qwenTranslate = qwenTranslate;
   window.qwenTranslateStream = qwenTranslateStream;
+  window.qwenTranslateBatch = qwenTranslateBatch;
   window.qwenClearCache = qwenClearCache;
 }
 if (typeof self !== 'undefined' && typeof window === 'undefined') {
   self.qwenTranslate = qwenTranslate;
   self.qwenTranslateStream = qwenTranslateStream;
+  self.qwenTranslateBatch = qwenTranslateBatch;
   self.qwenClearCache = qwenClearCache;
 }
 if (typeof module !== 'undefined') {
-  module.exports = { qwenTranslate, qwenTranslateStream, qwenClearCache };
+  module.exports = { qwenTranslate, qwenTranslateStream, qwenTranslateBatch, qwenClearCache };
 }


### PR DESCRIPTION
## Summary
- ensure background service worker replies to translate messages
- wrap `runtime.sendMessage` in a promise so content scripts always receive background responses
- log node translations and warn if output matches the source text
- keep a single throttling queue in the background worker to prevent bursts that trigger rate limits
- retry translation requests when the API responds with HTTP 429 and document the behaviour
- send a source-language sample in the tab-translation test so identical responses no longer trigger a false failure
- translate nodes inside shadow DOM roots and observe dynamically-added shadows
- track requests and tokens sent in the last minute and expose live usage bars in the popup UI
- batch DOM nodes into single translation requests and refresh usage bars every second
- re-queue failed translation batches for retry and mark identical results as untranslatable
- translate embedded frames and widgets via `all_frames` and `<all_urls>` permissions and batch up to 1000 tokens per API request
- preserve leading/trailing whitespace in translations and scan navigation/main content before the rest of the page for faster updates
- **show badge when translations are running and display total requests, tokens, and queue length in popup stats**
- **overlay status box reports translation activity and hides automatically when idle**
- **skip hidden or non-content nodes and cache duplicate strings to minimise API usage**

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688cd4fef6048323ad6171f665bd7fa7