### PR TITLE
Adjust PDF translation text scaling

### DIFF
--- a/src/pdfViewer.js
+++ b/src/pdfViewer.js
@@ -33,19 +33,16 @@
       canvas.height = viewport.height;
       pageDiv.appendChild(canvas);
       await page.render({ canvasContext: ctx, viewport }).promise;
-      const textLayerDiv = document.createElement('div');
-      textLayerDiv.className = 'textLayer';
-      pageDiv.appendChild(textLayerDiv);
       const textContent = await page.getTextContent();
-      const items = textContent.items.map(i => i.str);
-      let translated = items;
-      if (items.length) {
+      const original = textContent.items.map(i => i.str);
+      let translated = original;
+      if (original.length) {
         try {
           const res = await window.qwenTranslateBatch({
             endpoint: cfg.apiEndpoint,
             apiKey: cfg.apiKey,
             model: cfg.model,
-            texts: items,
+            texts: original,
             source: cfg.sourceLanguage,
             target: cfg.targetLanguage,
             debug: cfg.debug,
@@ -56,14 +53,34 @@
           console.error('PDF translation failed', e);
         }
       }
+      const measure = document.createElement('canvas').getContext('2d');
+      const vpTransform = viewport.transform;
       textContent.items.forEach((it, i) => {
-        it.str = translated[i];
-      });
-      pdfjsLib.renderTextLayer({
-        textContent,
-        container: textLayerDiv,
-        viewport,
-        textDivs: [],
+        const style = textContent.styles[it.fontName];
+        if (!style) return;
+        const fontSize = Math.hypot(it.transform[0], it.transform[1]);
+        measure.font = `${fontSize}px ${style.fontFamily}`;
+        const w = measure.measureText(translated[i]).width;
+        let a = it.transform[0];
+        let b = it.transform[1];
+        let c = it.transform[2];
+        let d = it.transform[3];
+        let e = it.transform[4];
+        let f = it.transform[5];
+        if (w > 0 && it.width) {
+          const scale = it.width / w;
+          a *= scale;
+          b *= scale;
+        }
+        const tr = pdfjsLib.Util.transform(vpTransform, [a, b, c, d, e, f]);
+        ctx.save();
+        ctx.setTransform(tr[0], tr[1], tr[2], tr[3], tr[4], tr[5]);
+        ctx.font = measure.font;
+        ctx.globalCompositeOperation = 'destination-out';
+        ctx.fillText(original[i], 0, 0);
+        ctx.globalCompositeOperation = 'source-over';
+        ctx.fillText(translated[i], 0, 0);
+        ctx.restore();
       });
     }
   } catch (e) {


### PR DESCRIPTION
## Summary
- erase original PDF text and draw translated text with the same fonts and scaled widths

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893bde6fc988323bb8599f156a945d3