### PR TITLE
chore(test): silence error logs; stabilize mocks

### DIFF
--- a/test/translator.test.js
+++ b/test/translator.test.js
@@ -17,8 +17,10 @@ test('translate success', async () => {
 });
 
 test('translate error', async () => {
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
   fetch.mockResponseOnce(JSON.stringify({message:'bad'}), {status:400});
   await expect(translate({endpoint:'https://e/', apiKey:'k', model:'m', text:'x', source:'es', target:'en'})).rejects.toThrow('bad');
+  spy.mockRestore();
 });
 
 test('translate caching', async () => {


### PR DESCRIPTION
Silence expected console.error in negative translation test to keep CI logs clean. Jest already uses jest-fetch-mock via setup; tools/ ignored to avoid haste-map collision.