### PR TITLE
feat: hide PDF save menu until translated

### DIFF
--- a/src/pdfViewer.html
+++ b/src/pdfViewer.html
@@ -20,7 +20,7 @@
       <button id="btnOriginal" class="btn" data-active="0">Original</button>
       <div class="btn-split">
         <button id="btnTranslated" class="btn" data-active="0">Translated</button>
-        <button id="btnTranslatedMenu" class="btn caret" title="More">▼</button>
+        <button id="btnTranslatedMenu" class="btn caret" title="More" style="display:none">▼</button>
         <div id="translatedMenu" class="dropdown">
           <button id="actionSaveTranslated" class="menu-item">Save translated PDF</button>
         </div>

--- a/src/pdfViewer.js
+++ b/src/pdfViewer.js
@@ -123,8 +123,18 @@ import { isWasmAvailable } from './wasm/engine.js';
   function setModeUI(mode) {
     if (btnOriginal) btnOriginal.dataset.active = mode === 'original' ? '1' : '0';
     if (btnTranslated) btnTranslated.dataset.active = mode === 'translated' ? '1' : '0';
-    if (badge) { badge.textContent = mode === 'translated' ? 'Translated' : 'Original'; badge.style.color = mode === 'translated' ? '#2e7d32' : '#666'; }
-    if (translatedMenu) translatedMenu.style.display = mode === 'translated' ? translatedMenu.style.display : 'none';
+    if (badge) {
+      badge.textContent = mode === 'translated' ? 'Translated' : 'Original';
+      badge.style.color = mode === 'translated' ? '#2e7d32' : '#666';
+    }
+    if (btnTranslatedMenu) btnTranslatedMenu.style.display = mode === 'translated' ? '' : 'none';
+    if (btnTranslated) {
+      btnTranslated.style.borderRadius =
+        btnTranslatedMenu && btnTranslatedMenu.style.display !== 'none'
+          ? '0'
+          : '0 8px 8px 0';
+    }
+    if (translatedMenu) translatedMenu.style.display = 'none';
   }
 
   async function generateTranslatedBlobUrl(originalUrl) {


### PR DESCRIPTION
## Summary
- Hide translated-PDF menu in PDF viewer until in translated mode
- Adjust toggle button styling when translation menu is hidden

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897d6118fa483239d4f39022c3b639e