### PR TITLE
fix: detect mupdf wasm asset

### DIFF
--- a/src/wasm/engine.js
+++ b/src/wasm/engine.js
@@ -9,12 +9,12 @@ async function check(base, path) {
   try { const r = await fetch(base + path, { method: 'HEAD' }); return r.ok; } catch { return false; }
 }
 
-async function chooseEngine(base, requested) {
+export async function chooseEngine(base, requested) {
   const wants = (requested || 'auto').toLowerCase();
   const hbOk = await check(base, 'hb.wasm');
   const icuOk = (await check(base, 'icu4x_segmenter.wasm')) || (await check(base, 'icu4x_segmenter_wasm_bg.wasm'));
   const pdfiumOk = await check(base, 'pdfium.wasm');
-  const mupdfOk = await check(base, 'mupdf.wasm');
+  const mupdfOk = (await check(base, 'mupdf.wasm')) || (await check(base, 'mupdf-wasm.wasm'));
   const overlayOk = await check(base, 'pdf-lib.js');
 
   function pick() {


### PR DESCRIPTION
## Summary
- detect MuPDF assets packaged as `mupdf-wasm.wasm`
- expose `chooseEngine` for reuse and testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897d91a2754832398daf3f20049235b