### PR TITLE
Fix DOM translation to preserve text node structure

### DIFF
--- a/test/contentScript.test.js
+++ b/test/contentScript.test.js
@@ -1,0 +1,21 @@
+global.chrome = { runtime: { getURL: () => 'chrome-extension://abc/', onMessage: { addListener: () => {} } } };
+
+window.qwenTranslateBatch = async ({ texts }) => ({ texts: texts.map(t => `X${t}X`) });
+window.qwenLoadConfig = async () => ({ apiKey: 'k', apiEndpoint: 'https://e/', model: 'm', sourceLanguage: 'nl', targetLanguage: 'en', debug: false });
+window.getComputedStyle = () => ({ visibility: 'visible', display: 'block' });
+Element.prototype.getClientRects = () => [1];
+
+const { translateBatch, collectNodes, setCurrentConfig } = require('../src/contentScript.js');
+
+test('translates text nodes without altering structure', async () => {
+  document.body.innerHTML = '<p class="bm-message-body"><span>Beste klant,</span><br><span>Bedankt dat u contact met ons opneemt.</span></p>';
+  setCurrentConfig({ apiKey: 'k', apiEndpoint: 'https://e/', model: 'm', sourceLanguage: 'nl', targetLanguage: 'en', debug: false });
+  const nodes = [];
+  collectNodes(document.body, nodes);
+  await translateBatch(nodes);
+  const p = document.querySelector('p');
+  expect(p.querySelectorAll('span').length).toBe(2);
+  expect(p.querySelector('br')).not.toBeNull();
+  expect(p.querySelectorAll('span')[0].textContent).toBe('XBeste klant,X');
+  expect(p.querySelectorAll('span')[1].textContent).toBe('XBedankt dat u contact met ons opneemt.X');
+});


### PR DESCRIPTION
## Summary
- Translate and mark individual text nodes instead of parent elements to avoid removing spans and other structural tags
- Add unit test ensuring translation keeps nested message markup intact

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899d90d942c8323a4895f0a73d08348