### PR TITLE
fix: improve wasm readiness check and ui

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -61,33 +61,42 @@ async function updateIcon() {
   const c = new OffscreenCanvas(size, size);
   const ctx = c.getContext('2d');
   ctx.clearRect(0, 0, size, size);
-  ctx.fillStyle = '#fff';
-  ctx.fillRect(0, 0, size, size);
-  const pulse = activeTranslations > 0 ? 0.6 + 0.4 * Math.sin(iconFrame / 3) : 1;
-  // outer activity ring
-  ctx.strokeStyle = activeTranslations > 0 ? `rgba(13,110,253,${pulse})` : '#adb5bd';
-  ctx.lineWidth = activeTranslations > 0 ? 4 : 3;
-  ctx.beginPath();
-  ctx.arc(9.5, 9.5, 8, 0, Math.PI * 2);
-  ctx.stroke();
+  // outer activity ring / spinner
+  ctx.lineWidth = 3;
+  if (activeTranslations > 0) {
+    const angle = (iconFrame / 10) % (Math.PI * 2);
+    ctx.strokeStyle = '#0d6efd';
+    ctx.beginPath();
+    ctx.arc(9.5, 9.5, 8, angle, angle + Math.PI / 2);
+    ctx.stroke();
+  } else {
+    ctx.strokeStyle = '#adb5bd';
+    ctx.beginPath();
+    ctx.arc(9.5, 9.5, 8, 0, Math.PI * 2);
+    ctx.stroke();
+  }
   // usage rings
   const blink = iconFrame % 20 < 10;
-  ctx.lineCap = 'butt';
+  ctx.lineCap = 'round';
   ctx.lineWidth = 4;
+  // request ring background
+  ctx.strokeStyle = '#e9ecef';
+  ctx.beginPath();
+  ctx.arc(9.5, 9.5, 6, 0, Math.PI * 2);
+  ctx.stroke();
   ctx.strokeStyle = requestLimit - requests <= 0 && blink ? '#fff' : reqColor;
   ctx.beginPath();
   ctx.arc(9.5, 9.5, 6, -Math.PI / 2, -Math.PI / 2 + 2 * Math.PI * reqPct);
+  ctx.stroke();
+  // token ring background
+  ctx.beginPath();
+  ctx.strokeStyle = '#e9ecef';
+  ctx.arc(9.5, 9.5, 3, 0, Math.PI * 2);
   ctx.stroke();
   ctx.strokeStyle = tokenLimit - tokens <= 0 && blink ? '#fff' : tokColor;
   ctx.beginPath();
   ctx.arc(9.5, 9.5, 3, -Math.PI / 2, -Math.PI / 2 + 2 * Math.PI * tokPct);
   ctx.stroke();
-  if (activeTranslations > 0) {
-    ctx.fillStyle = '#0d6efd';
-    ctx.beginPath();
-    ctx.arc(9.5, 9.5, 2.5, 0, Math.PI * 2);
-    ctx.fill();
-  }
   const imageData = ctx.getImageData(0, 0, size, size);
   chrome.action.setIcon({ imageData: { 19: imageData } });
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -6,32 +6,33 @@
     body {
       font-family: system-ui, sans-serif;
       width: 360px;
-      min-height: 640px;
-      padding: 12px;
+      padding: 16px;
       margin: 0;
       background: #fff;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
     }
     label {
-      display: block;
-      margin-top: 8px;
       font-size: 12px;
       color: #333;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
     }
     input[type=text], input[type=number], select {
       width: 100%;
       box-sizing: border-box;
-      margin-top: 4px;
       padding: 6px 8px;
       border: 1px solid #ccc;
-      border-radius: 4px;
+      border-radius: 6px;
       background: #fafafa;
     }
     button {
       width: 100%;
-      margin-top: 10px;
       padding: 8px;
       border: none;
-      border-radius: 4px;
+      border-radius: 6px;
       background: #1976d2;
       color: #fff;
       font-weight: 600;
@@ -44,7 +45,6 @@
     }
     .buttons button { flex: 1; }
     #status {
-      margin-top: 8px;
       font-size: 12px;
       color: #555;
       min-height: 40px;
@@ -55,13 +55,13 @@
       background: #fafafa;
     }
     #usage {
-      margin-top: 12px;
       font-size: 11px;
+      display: grid;
+      gap: 4px;
     }
     .bar {
       height: 6px;
       background: #eee;
-      margin-top: 2px;
       border-radius: 3px;
       overflow: hidden;
     }
@@ -73,7 +73,6 @@
     #version {
       font-size: 11px;
       color: #777;
-      margin-top: 6px;
       text-align: center;
     }
   </style>

--- a/src/wasm/engine.js
+++ b/src/wasm/engine.js
@@ -6,13 +6,15 @@ let _impl = null;
 let _lastChoice = 'auto';
 
 async function check(base, path) {
+  const url = base + path;
   try {
-    // Some environments disallow HEAD for extension resources; fetch a single byte instead
-    const r = await fetch(base + path, {
-      method: 'GET',
-      headers: { Range: 'bytes=0-0' },
-    });
-    return r.ok;
+    const head = await fetch(url, { method: 'HEAD' });
+    if (head.ok) return true;
+  } catch {}
+  try {
+    // Fallback for environments where HEAD is disallowed
+    const get = await fetch(url);
+    return get.ok;
   } catch {
     return false;
   }
@@ -103,4 +105,8 @@ export async function isWasmAvailable(cfg) {
 export async function rewritePdf(buffer, cfg, onProgress) {
   const impl = await loadEngine(cfg);
   return impl.rewritePdf(buffer, cfg, onProgress);
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { chooseEngine, isWasmAvailable, rewritePdf };
 }


### PR DESCRIPTION
## Summary
- ensure WASM engine asset check falls back to GET when HEAD fails
- restyle popup to show all settings without scrolling
- redraw action icon with transparent background, spinner, and clearer rate limit rings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899ea16794483238ba23761dc05b54a