### PR TITLE
Handle missing MuPDF loader in engine selection

### DIFF
--- a/scripts/fetch-wasm-assets.sh
+++ b/scripts/fetch-wasm-assets.sh
@@ -12,22 +12,34 @@ echo "Vendor dir: $VENDOR_DIR"
 # 1) MuPDF
 echo "Downloading MuPDF..."
 curl -L -o "$VENDOR_DIR/mupdf.wasm" https://unpkg.com/mupdf@1.26.4/dist/mupdf-wasm.wasm
+curl -L -o "$VENDOR_DIR/mupdf-wasm.js" https://unpkg.com/mupdf@1.26.4/dist/mupdf-wasm.js
 curl -L -o "$VENDOR_DIR/mupdf.engine.js" https://unpkg.com/mupdf@1.26.4/dist/mupdf.js
 
-# 2) HarfBuzz
+# 2) PDFium
+echo "Downloading PDFium..."
+curl -L -o "$VENDOR_DIR/pdfium.wasm" https://unpkg.com/pdfium-wasm@0.0.2/dist/pdfium.wasm
+curl -L -o "$VENDOR_DIR/pdfium.js" https://unpkg.com/pdfium-wasm@0.0.2/dist/pdfium.js
+curl -L -o "$VENDOR_DIR/pdfium.engine.js" https://raw.githubusercontent.com/alibaba/Qwen-translator-extension/main/src/wasm/vendor/pdfium.engine.js
+
+# 3) HarfBuzz
 echo "Downloading HarfBuzz..."
 curl -L -o "$VENDOR_DIR/hb.wasm" https://unpkg.com/harfbuzzjs@0.4.8/hb.wasm
 curl -L -o "$VENDOR_DIR/hb.js" https://unpkg.com/harfbuzzjs@0.4.8/hb.js
 
-# 3) pdf-lib
-echo "Downloading pdf-lib..."
-curl -L -o "$VENDOR_DIR/pdf-lib.js" https://unpkg.com/pdf-lib@1.17.1/dist/pdf-lib.min.js
+# 4) ICU4X segmenter
+echo "Downloading ICU4X segmenter..."
+curl -L -o "$VENDOR_DIR/icu4x_segmenter.wasm" https://raw.githubusercontent.com/alibaba/Qwen-translator-extension/main/src/wasm/vendor/icu4x_segmenter.wasm
+curl -L -o "$VENDOR_DIR/icu4x_segmenter.js" https://raw.githubusercontent.com/alibaba/Qwen-translator-extension/main/src/wasm/vendor/icu4x_segmenter.js
 
-# 4) Noto Fonts
+# 5) pdf-lib and wrappers
+echo "Downloading pdf-lib and wrappers..."
+curl -L -o "$VENDOR_DIR/pdf-lib.js" https://unpkg.com/pdf-lib@1.17.1/dist/pdf-lib.min.js
+curl -L -o "$VENDOR_DIR/overlay.engine.js" https://raw.githubusercontent.com/alibaba/Qwen-translator-extension/main/src/wasm/vendor/overlay.engine.js
+curl -L -o "$VENDOR_DIR/simple.engine.js" https://raw.githubusercontent.com/alibaba/Qwen-translator-extension/main/src/wasm/vendor/simple.engine.js
+
+# 6) Noto Fonts
 echo "Downloading Noto Fonts..."
 curl -L -o "$VENDOR_DIR/fonts/NotoSans-Regular.ttf" "https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A99d.ttf"
 curl -L -o "$VENDOR_DIR/fonts/NotoSans-Bold.ttf" "https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyAaBN9d.ttf"
-
-# The icu4x_segmenter is bundled with the extension, so we don't download it.
 
 echo "All assets downloaded successfully."

--- a/src/pdfViewer.html
+++ b/src/pdfViewer.html
@@ -32,8 +32,9 @@
       </div>
     </div>
     <span class="sep"></span>
-    <select id="engineSelect" class="btn" title="Translation engine"></select>
-    <span id="engineStatus" class="muted">Engine: checking…</span>
+      <select id="engineSelect" class="btn" title="Translation engine"></select>
+      <span id="engineStatus" class="muted">Engine: checking…</span>
+      <button id="downloadEngines" class="btn" style="display:none">Setup engines</button>
     <span class="sep"></span>
     <div class="toggle-group">
       <button id="zoomOut" class="btn">-</button>

--- a/src/pdfViewer.js
+++ b/src/pdfViewer.js
@@ -1,5 +1,5 @@
 import { regeneratePdfFromUrl } from './wasm/pipeline.js';
-import { isWasmAvailable } from './wasm/engine.js';
+import { chooseEngine, WASM_ASSETS } from './wasm/engine.js';
 import { safeFetchPdf } from './wasm/pdfFetch.js';
 
 (async function() {
@@ -119,25 +119,16 @@ import { safeFetchPdf } from './wasm/pdfFetch.js';
     }
   });
 
-  // Setup engine dropdown with available options and sensible default
+  // Setup engine dropdown and status with available options and sensible default
   (async () => {
     try {
       const vendorBase = chrome.runtime.getURL('wasm/vendor/');
-      async function head(u){ try{ const r=await fetch(u,{method:'HEAD'}); return r.ok; }catch{return false;} }
-      const avail = {
-        mupdf: await head(vendorBase+'mupdf.engine.js') && await head(vendorBase+'mupdf.wasm'),
-        pdfium:
-          (await head(vendorBase+'pdfium.engine.js')) &&
-          (await head(vendorBase+'pdfium.js')) &&
-          (await head(vendorBase+'pdfium.wasm')),
-        overlay: await head(vendorBase+'pdf-lib.js'),
-        simple: true,
-      };
+      const { hbOk, icuOk, pdfiumOk, mupdfOk, overlayOk } = await chooseEngine(vendorBase, cfg.wasmEngine);
+      const avail = { mupdf: mupdfOk, pdfium: pdfiumOk, overlay: overlayOk, simple: true };
       const best = avail.mupdf ? 'mupdf' : (avail.pdfium ? 'pdfium' : (avail.overlay ? 'overlay' : 'simple'));
       const sel = document.getElementById('engineSelect');
       if (sel && !sel.dataset.inited) {
         sel.dataset.inited = '1';
-        // Build options list
         const opts = [];
         opts.push({ v: 'auto', t: 'Engine: Auto' });
         if (avail.mupdf) opts.push({ v: 'mupdf', t: 'Engine: MuPDF' });
@@ -145,7 +136,6 @@ import { safeFetchPdf } from './wasm/pdfFetch.js';
         if (avail.overlay) opts.push({ v: 'overlay', t: 'Engine: Overlay' });
         opts.push({ v: 'simple', t: 'Engine: Simple' });
         sel.innerHTML = opts.map(o => `<option value="${o.v}">${o.t}</option>`).join('');
-        // Load stored choice; if none, choose best available
         chrome.storage.sync.get({ wasmEngine: cfg.wasmEngine || '' }, s => {
           const choice = s.wasmEngine || best || 'auto';
           sel.value = choice;
@@ -154,7 +144,41 @@ import { safeFetchPdf } from './wasm/pdfFetch.js';
           chrome.storage.sync.set({ wasmEngine: sel.value });
         });
       }
-    } catch {}
+      const statEl = document.getElementById('engineStatus');
+      if (statEl) {
+        const names = [];
+        if (mupdfOk) names.push('MuPDF');
+        if (pdfiumOk) names.push('PDFium');
+        if (overlayOk) names.push('Overlay');
+        if (names.length) {
+          statEl.textContent = `Available engines: ${names.join(', ')}`;
+          statEl.style.color = '#2e7d32';
+        } else {
+          statEl.textContent = 'No PDF engines available';
+          statEl.style.color = '#d32f2f';
+        }
+      }
+      const dlBtn = document.getElementById('downloadEngines');
+      if (dlBtn) {
+        if (!hbOk || !icuOk || !mupdfOk || !pdfiumOk || !overlayOk) {
+          dlBtn.style.display = '';
+          dlBtn.addEventListener('click', () => {
+            WASM_ASSETS.forEach(a => {
+              chrome.downloads.download({ url: a.url, filename: `wasm/vendor/${a.path}` });
+            });
+            alert('After download, copy the "wasm" folder into the extension directory (merge with existing files) and reload.');
+          });
+        } else {
+          dlBtn.style.display = 'none';
+        }
+      }
+    } catch (e) {
+      const statEl = document.getElementById('engineStatus');
+      if (statEl) {
+        statEl.textContent = 'Engine: Unknown';
+        statEl.style.color = '#f57c00';
+      }
+    }
   })();
 
   // Wire up view toggles and save menu
@@ -275,24 +299,6 @@ import { safeFetchPdf } from './wasm/pdfFetch.js';
       console.error('Auto-translate preview failed', e);
     }
   }
-    // Show engine readiness status
-  (async () => {
-    const statEl = document.getElementById('engineStatus');
-    if (!statEl) return;
-    try {
-      const ready = await isWasmAvailable(cfg);
-      if (ready) {
-        statEl.textContent = 'Engine: Ready';
-        statEl.style.color = '#2e7d32';
-      } else {
-        statEl.textContent = 'Engine: Missing components (requires: hb.wasm, pdfium.wasm, mupdf.wasm or mupdf-wasm.wasm, icu4x_segmenter.wasm, pdf-lib.js)';
-        statEl.style.color = '#d32f2f';
-      }
-    } catch (e) {
-      statEl.textContent = 'Engine: Unknown';
-      statEl.style.color = '#f57c00';
-    }
-  })();
   if (!cfg.apiKey) {
     viewer.textContent = 'API key not configured';
     console.log('DEBUG: API key not configured.');

--- a/src/wasm/engine.js
+++ b/src/wasm/engine.js
@@ -1,6 +1,45 @@
 // WASM engine loader and interface (MuPDF/PDFium + HarfBuzz + ICU4X + Noto)
 // Looks for vendor assets under src/wasm/vendor/ and loads the selected engine.
 
+export const WASM_ASSETS = [
+  { path: 'mupdf.wasm', url: 'https://unpkg.com/mupdf@1.26.4/dist/mupdf-wasm.wasm' },
+  { path: 'mupdf-wasm.js', url: 'https://unpkg.com/mupdf@1.26.4/dist/mupdf-wasm.js' },
+  { path: 'mupdf.engine.js', url: 'https://unpkg.com/mupdf@1.26.4/dist/mupdf.js' },
+  { path: 'pdfium.wasm', url: 'https://unpkg.com/pdfium-wasm@0.0.2/dist/pdfium.wasm' },
+  { path: 'pdfium.js', url: 'https://unpkg.com/pdfium-wasm@0.0.2/dist/pdfium.js' },
+  {
+    path: 'pdfium.engine.js',
+    url: 'https://raw.githubusercontent.com/alibaba/Qwen-translator-extension/main/src/wasm/vendor/pdfium.engine.js',
+  },
+  { path: 'hb.wasm', url: 'https://unpkg.com/harfbuzzjs@0.4.8/hb.wasm' },
+  { path: 'hb.js', url: 'https://unpkg.com/harfbuzzjs@0.4.8/hb.js' },
+  {
+    path: 'icu4x_segmenter.wasm',
+    url: 'https://raw.githubusercontent.com/alibaba/Qwen-translator-extension/main/src/wasm/vendor/icu4x_segmenter.wasm',
+  },
+  {
+    path: 'icu4x_segmenter.js',
+    url: 'https://raw.githubusercontent.com/alibaba/Qwen-translator-extension/main/src/wasm/vendor/icu4x_segmenter.js',
+  },
+  { path: 'pdf-lib.js', url: 'https://unpkg.com/pdf-lib@1.17.1/dist/pdf-lib.min.js' },
+  {
+    path: 'overlay.engine.js',
+    url: 'https://raw.githubusercontent.com/alibaba/Qwen-translator-extension/main/src/wasm/vendor/overlay.engine.js',
+  },
+  {
+    path: 'simple.engine.js',
+    url: 'https://raw.githubusercontent.com/alibaba/Qwen-translator-extension/main/src/wasm/vendor/simple.engine.js',
+  },
+  {
+    path: 'fonts/NotoSans-Regular.ttf',
+    url: 'https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A99d.ttf',
+  },
+  {
+    path: 'fonts/NotoSans-Bold.ttf',
+    url: 'https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyAaBN9d.ttf',
+  },
+];
+
 let available = false;
 let _impl = null;
 let _lastChoice = 'auto';
@@ -30,7 +69,8 @@ export async function chooseEngine(base, requested) {
     (await check(base, 'pdfium.wasm'));
   const mupdfOk =
     (await check(base, 'mupdf.engine.js')) &&
-    (await check(base, 'mupdf.wasm'));
+    (await check(base, 'mupdf-wasm.js')) &&
+    ((await check(base, 'mupdf.wasm')) || (await check(base, 'mupdf-wasm.wasm')));
   const overlayOk = await check(base, 'pdf-lib.js');
 
   function pick() {
@@ -45,7 +85,24 @@ export async function chooseEngine(base, requested) {
     return 'simple';
   }
   const choice = pick();
-  return { choice, hbOk, icuOk, pdfiumOk, mupdfOk };
+  return { choice, hbOk, icuOk, pdfiumOk, mupdfOk, overlayOk };
+}
+
+export async function downloadWasmAssets(dir, downloader) {
+  const fs = require('fs');
+  const path = require('path');
+  const dl =
+    downloader ||
+    (async (url, dest) => {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error('Failed to download ' + url);
+      const buf = Buffer.from(await res.arrayBuffer());
+      await fs.promises.mkdir(path.dirname(dest), { recursive: true });
+      await fs.promises.writeFile(dest, buf);
+    });
+  for (const a of WASM_ASSETS) {
+    await dl(a.url, path.join(dir, a.path));
+  }
 }
 
 async function loadEngine(cfg) {
@@ -108,5 +165,11 @@ export async function rewritePdf(buffer, cfg, onProgress) {
 }
 
 if (typeof module !== 'undefined') {
-  module.exports = { chooseEngine, isWasmAvailable, rewritePdf };
+  module.exports = {
+    chooseEngine,
+    isWasmAvailable,
+    rewritePdf,
+    WASM_ASSETS,
+    downloadWasmAssets,
+  };
 }

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadEngine() {
+  const code = fs.readFileSync(path.join(__dirname, '../src/wasm/engine.js'), 'utf8');
+  const transformed = code
+    .replace(/export\s+/g, '')
+    .replace(/import\.meta/g, '({url: ""})');
+  const module = { exports: {} };
+  const fn = new Function('require', 'module', 'exports', transformed + '\nreturn module.exports;');
+  return fn(require, module, module.exports);
+}
+
+describe('chooseEngine', () => {
+  const origFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = origFetch;
+  });
+
+  it('falls back when mupdf loader is missing', async () => {
+    const { chooseEngine } = loadEngine();
+    const ok = new Set([
+      'base/mupdf.engine.js',
+      'base/mupdf.wasm',
+      'base/pdfium.engine.js',
+      'base/pdfium.js',
+      'base/pdfium.wasm',
+      'base/hb.wasm',
+      'base/icu4x_segmenter.wasm',
+      'base/pdf-lib.js',
+    ]);
+    global.fetch = jest.fn((url) => {
+      if (ok.has(url)) return Promise.resolve({ ok: true });
+      return Promise.reject(new Error('missing'));
+    });
+    const { choice, mupdfOk, pdfiumOk } = await chooseEngine('base/', 'auto');
+    expect(mupdfOk).toBe(false);
+    expect(pdfiumOk).toBe(true);
+    expect(choice).toBe('pdfium');
+  });
+
+  it('loads engines after assets downloaded', async () => {
+    const { chooseEngine, WASM_ASSETS, downloadWasmAssets } = loadEngine();
+  const os = require('os');
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wasm-'));
+  await downloadWasmAssets(tmp, (url, dest) => {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.writeFileSync(dest, '');
+  });
+  global.fetch = jest.fn(url => {
+    const rel = url.replace('base/', '');
+    const p = path.join(tmp, rel);
+    if (fs.existsSync(p)) return Promise.resolve({ ok: true });
+    return Promise.reject(new Error('missing'));
+    });
+    const { choice, mupdfOk, pdfiumOk } = await chooseEngine('base/', 'auto');
+    for (const a of WASM_ASSETS) {
+      expect(fs.existsSync(path.join(tmp, a.path))).toBe(true);
+    }
+    expect(mupdfOk).toBe(true);
+    expect(pdfiumOk).toBe(true);
+    expect(choice).toBe('mupdf');
+  });
+});


### PR DESCRIPTION
## Summary
- include ICU4X segmenter assets in canonical WASM download list
- save downloaded engine assets into `wasm/vendor/` and prompt user to copy folder into the extension
- fetch MuPDF loader via helper script and adjust tests for new asset set
- add vendor wrappers and Noto fonts to asset download list so users get a complete bundle

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a0a56cf908323a5087afce99513f9