### PR TITLE
Add PDFium engine smoke test and adjust engine selection

### DIFF
--- a/e2e/engine-smoke.spec.js
+++ b/e2e/engine-smoke.spec.js
@@ -33,4 +33,8 @@ test.describe('Engine smoke', () => {
   test('Overlay engine smoke', async ({ page }) => {
     await runSmoke(page, 'overlay');
   });
+
+  test('PDFium engine smoke', async ({ page }) => {
+    await runSmoke(page, 'pdfium');
+  });
 });

--- a/src/wasm/engine.js
+++ b/src/wasm/engine.js
@@ -79,8 +79,8 @@ export async function chooseEngine(base, requested) {
     if (wants === 'overlay') return 'overlay';
     if (wants === 'simple') return 'simple';
     // auto: prefer MuPDF if present; else PDFium; else Overlay; else Simple
-    if (mupdfOk) return 'mupdf';
     if (pdfiumOk) return 'pdfium';
+    if (mupdfOk) return 'mupdf';
     if (overlayOk) return 'overlay';
     return 'simple';
   }

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -59,6 +59,6 @@ describe('chooseEngine', () => {
     }
     expect(mupdfOk).toBe(true);
     expect(pdfiumOk).toBe(true);
-    expect(choice).toBe('mupdf');
+    expect(choice).toBe('pdfium');
   });
 });


### PR DESCRIPTION
## Summary
- prefer PDFium over MuPDF when selecting a WASM engine
- exercise PDFium engine in Playwright smoke test
- update unit tests for the new default engine

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689a6d8e635c8323b475aff13f0c1c0a