### PR TITLE
fix: prefix API key with bearer

### DIFF
--- a/src/translator.js
+++ b/src/translator.js
@@ -74,11 +74,12 @@ async function doFetch({ endpoint, apiKey, model, text, source, target, signal, 
     },
   };
   if (debug) console.log('QTDEBUG: request body', body);
+  const auth = apiKey && /^bearer\s/i.test(apiKey) ? apiKey : `Bearer ${apiKey}`;
   let resp;
   try {
     const headers = {
       'Content-Type': 'application/json',
-      Authorization: apiKey,
+      Authorization: auth,
     };
     if (stream) headers['X-DashScope-SSE'] = 'enable';
     resp = await fetchFn(url, {
@@ -100,7 +101,7 @@ async function doFetch({ endpoint, apiKey, model, text, source, target, signal, 
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: apiKey,
+            Authorization: auth,
           },
           body: JSON.stringify(body),
           signal,

--- a/test/translator.test.js
+++ b/test/translator.test.js
@@ -17,6 +17,13 @@ test('translate success', async () => {
   expect(res.text).toBe('hello');
 });
 
+test('adds bearer prefix automatically', async () => {
+  fetch.mockResponseOnce(JSON.stringify({output:{text:'hello'}}));
+  await translate({endpoint:'https://e/', apiKey:'abc123', model:'m', text:'hi', source:'en', target:'es'});
+  const headers = fetch.mock.calls[0][1].headers;
+  expect(headers.Authorization).toBe('Bearer abc123');
+});
+
 test('translate error', async () => {
   const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
   fetch.mockResponseOnce(JSON.stringify({message:'bad'}), {status:400});


### PR DESCRIPTION
## Summary
- ensure API key is sent with a `Bearer` prefix when missing
- cover authorization header behavior with new translator unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aad9c13ac8323b248d3c8129ae377