### PR TITLE
fix: prefix API key with bearer

### DIFF
--- a/src/translator.js
+++ b/src/translator.js
@@ -74,13 +74,12 @@ async function doFetch({ endpoint, apiKey, model, text, source, target, signal, 
     },
   };
   if (debug) console.log('QTDEBUG: request body', body);
+  const key = (apiKey || '').trim();
+  const headers = { 'Content-Type': 'application/json' };
+  if (key) headers.Authorization = /^bearer\s/i.test(key) ? key : `Bearer ${key}`;
+  if (stream) headers['X-DashScope-SSE'] = 'enable';
   let resp;
   try {
-    const headers = {
-      'Content-Type': 'application/json',
-      Authorization: apiKey,
-    };
-    if (stream) headers['X-DashScope-SSE'] = 'enable';
     resp = await fetchFn(url, {
       method: 'POST',
       headers,
@@ -98,10 +97,7 @@ async function doFetch({ endpoint, apiKey, model, text, source, target, signal, 
         url,
         {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: apiKey,
-          },
+          headers,
           body: JSON.stringify(body),
           signal,
         },

--- a/src/wasm/vendor/simple.engine.js
+++ b/src/wasm/vendor/simple.engine.js
@@ -41,7 +41,7 @@ function buildSimplePdf(pages, onProgress) {
       y -= leading;
     });
     stream += 'ET\n';
-    const content = `<< /Length ${stream.length} >>\nstream\n${stream}endstream`;
+    const content = `<< /Length ${stream.length} >>\nstream\n${stream}endstream\n`;
     contentObjs.push({ num: contentNum, body: content });
     if (onProgress) onProgress({ phase: 'render', page: i + 1, total: pages.length });
   });
@@ -50,10 +50,10 @@ function buildSimplePdf(pages, onProgress) {
   add('1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj');
   add(`2 0 obj << /Type /Pages /Count ${pages.length} /Kids [ ${kids.join(' ')} ] >> endobj`);
   add('3 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj');
-  pageObjs.forEach((p, idx) => {
+  pageObjs.forEach((p) => {
     add(`${p.num} 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 ${Math.round(p.w)} ${Math.round(p.h)}] /Resources << /Font << /F1 3 0 R >> >> /Contents ${p.content} >> endobj`);
   });
-  contentObjs.forEach((c) => add(`${c.num} 0 obj ${c.body} endobj`));
+  contentObjs.forEach((c) => add(`${c.num} 0 obj\n${c.body}endobj`));
 
   const xrefPos = buf.length;
   buf += 'xref\n';

--- a/test/simple.engine.test.js
+++ b/test/simple.engine.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const { TextEncoder } = require('util');
+
+global.TextEncoder = TextEncoder;
+class FakeBlob {
+  constructor(parts) { this.data = parts[0]; }
+  text() { return Promise.resolve(Buffer.from(this.data).toString()); }
+}
+global.Blob = FakeBlob;
+
+function loadBuilder() {
+  const code = fs.readFileSync(path.join(__dirname, '../src/wasm/vendor/simple.engine.js'), 'utf8');
+  const transformed = code.replace(/export\s+/g, '');
+  const fn = new Function(transformed + '\nreturn { buildSimplePdf };');
+  return fn().buildSimplePdf;
+}
+
+describe('buildSimplePdf', () => {
+  it('creates a PDF that can be parsed', async () => {
+    const buildSimplePdf = loadBuilder();
+    const blob = buildSimplePdf([{ width: 200, height: 200, lines: ['hello world'] }]);
+    const text = await blob.text();
+    expect(text.startsWith('%PDF-')).toBe(true);
+  });
+});

--- a/test/translator.test.js
+++ b/test/translator.test.js
@@ -17,6 +17,27 @@ test('translate success', async () => {
   expect(res.text).toBe('hello');
 });
 
+test('adds bearer prefix automatically', async () => {
+  fetch.mockResponseOnce(JSON.stringify({output:{text:'hello'}}));
+  await translate({endpoint:'https://e/', apiKey:'abc123', model:'m', text:'hi', source:'en', target:'es'});
+  const headers = fetch.mock.calls[0][1].headers;
+  expect(headers.Authorization).toBe('Bearer abc123');
+});
+
+test('uses existing bearer prefix after trimming', async () => {
+  fetch.mockResponseOnce(JSON.stringify({output:{text:'ok'}}));
+  await translate({endpoint:'https://e/', apiKey:'  Bearer xyz  ', model:'m', text:'hi', source:'en', target:'es'});
+  const headers = fetch.mock.calls[0][1].headers;
+  expect(headers.Authorization).toBe('Bearer xyz');
+});
+
+test('omits authorization header when api key missing', async () => {
+  fetch.mockResponseOnce(JSON.stringify({output:{text:'hi'}}));
+  await translate({endpoint:'https://e/', apiKey:'', model:'m', text:'hi', source:'en', target:'es'});
+  const headers = fetch.mock.calls[0][1].headers;
+  expect(headers.Authorization).toBeUndefined();
+});
+
 test('translate error', async () => {
   const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
   fetch.mockResponseOnce(JSON.stringify({message:'bad'}), {status:400});


### PR DESCRIPTION
## Summary
- ensure API key is sent with a `Bearer` prefix when missing
- trim API key before constructing Authorization header and skip it when empty
- finalize simple PDF stream output so generated PDFs load correctly
- cover simple PDF generation with a header validation test

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aad9c13ac8323b248d3c8129ae377