### PR TITLE
fix: robust batch translation and adaptive throttle

### DIFF
--- a/test/throttle.test.js
+++ b/test/throttle.test.js
@@ -1,0 +1,19 @@
+const { runWithRateLimit, configure } = require('../src/throttle');
+
+jest.useFakeTimers();
+
+test('adaptive throttle delays after half usage', async () => {
+  configure({ requestLimit: 4, tokenLimit: 1000, windowMs: 1000 });
+  const calls = [];
+  const mk = id => () => { calls.push(id); return Promise.resolve(id); };
+  runWithRateLimit(mk('a'), 1);
+  runWithRateLimit(mk('b'), 1);
+  runWithRateLimit(mk('c'), 1);
+  runWithRateLimit(mk('d'), 1);
+  await Promise.resolve();
+  expect(calls).toEqual(['a', 'b', 'c']);
+  jest.advanceTimersByTime(250);
+  await Promise.resolve();
+  expect(calls).toEqual(['a', 'b', 'c', 'd']);
+  jest.useRealTimers();
+});

--- a/test/translator.test.js
+++ b/test/translator.test.js
@@ -211,6 +211,23 @@ test('batch groups multiple texts into single request by default', async () => {
   expect(fetch).toHaveBeenCalledTimes(1);
 });
 
+test('batch falls back on separator mismatch', async () => {
+  fetch
+    .mockResponseOnce(JSON.stringify({ output: { text: 'A' } }))
+    .mockResponseOnce(JSON.stringify({ output: { text: 'A1' } }))
+    .mockResponseOnce(JSON.stringify({ output: { text: 'B1' } }));
+  const res = await qwenTranslateBatch({
+    texts: ['a', 'b'],
+    source: 'en',
+    target: 'es',
+    endpoint: 'https://e/',
+    apiKey: 'k',
+    model: 'm',
+  });
+  expect(res.texts).toEqual(['A1', 'B1']);
+  expect(fetch).toHaveBeenCalledTimes(3);
+});
+
 test('batch reports stats and progress', async () => {
   fetch.mockResponseOnce(JSON.stringify({ output: { text: 'A\uE000B' } }));
   const events = [];


### PR DESCRIPTION
## Summary
- detect mismatched batch responses and fallback to per-item translation
- adapt rate limiting to slow down when half of request/token window is used
- cover edge cases with new unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bb0d632408323b95a0c7038e81cc8