### PR TITLE
refactor: isolate provider transport layer

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,4 +1,4 @@
-importScripts('throttle.js', 'lz-string.min.js', 'cache.js', 'providers/index.js', 'providers/qwen.js', 'translator.js', 'usageColor.js');
+importScripts('throttle.js', 'lz-string.min.js', 'cache.js', 'providers/index.js', 'providers/qwen.js', 'transport.js', 'translator.js', 'usageColor.js');
 
 chrome.storage.sync.get(
   { cacheMaxEntries: 1000, cacheTTL: 30 * 24 * 60 * 60 * 1000 },
@@ -156,7 +156,7 @@ function recordUsage(model, tokensIn, tokensOut) {
 }
 
 async function handleTranslate(opts) {
-  const { provider = 'qwen', endpoint, apiKey, model, text, source, target, debug } = opts;
+  const { provider = 'qwen', endpoint, apiKey, model, models, text, source, target, debug } = opts;
   if (debug) console.log('QTDEBUG: background translating via', endpoint);
 
   await ensureThrottle();

--- a/src/batch.js
+++ b/src/batch.js
@@ -10,6 +10,7 @@
   if (typeof window === 'undefined') {
     ({ approxTokens, getUsage } = require('./throttle'));
     ({ cacheReady, getCache, setCache, removeCache } = require('./cache'));
+    require('./transport');
     ({ qwenTranslate } = require('./translator'));
   } else {
     if (window.qwenThrottle) {
@@ -32,6 +33,7 @@
     } else if (typeof self !== 'undefined' && self.qwenTranslate) {
       qwenTranslate = self.qwenTranslate;
     } else if (typeof require !== 'undefined') {
+      require('./transport');
       ({ qwenTranslate } = require('./translator'));
     }
   }

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -1,3 +1,6 @@
+if (typeof window === 'undefined' && typeof require !== 'undefined') {
+  require('./transport');
+}
 if (!location.href.startsWith(chrome.runtime.getURL('pdfViewer.html'))) {
 let observers = [];
 let currentConfig;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -29,7 +29,7 @@
   "web_accessible_resources": [
     {
       "resources": [
-        "translator.js", "batch.js", "config.js", "languages.js", "throttle.js", "lz-string.min.js", "cache.js", "providers/index.js", "providers/qwen.js",
+        "transport.js", "translator.js", "batch.js", "config.js", "languages.js", "throttle.js", "lz-string.min.js", "cache.js", "providers/index.js", "providers/qwen.js",
         "pdfViewer.html", "pdfViewer.js", "sessionPdf.js", "pdf.min.js", "pdf.worker.min.js",
         "wasm/pipeline.js", "wasm/pdfgen.js", "wasm/engine.js",
         "wasm/vendor/hb.wasm", "wasm/vendor/icu4x_segmenter.wasm",
@@ -44,7 +44,7 @@
   "content_scripts": [
     {
       "matches": ["http://*/*", "https://*/*", "file:///*"],
-      "js": ["config.js", "throttle.js", "lz-string.min.js", "cache.js", "providers/index.js", "providers/qwen.js", "translator.js", "batch.js", "contentScript.js"],
+      "js": ["config.js", "throttle.js", "lz-string.min.js", "cache.js", "providers/index.js", "providers/qwen.js", "transport.js", "translator.js", "batch.js", "contentScript.js"],
       "run_at": "document_idle",
       "all_frames": true
     }

--- a/src/popup.js
+++ b/src/popup.js
@@ -29,6 +29,17 @@ const totalTok = document.getElementById('totalTok');
 const queueLen = document.getElementById('queueLen');
 const failedReq = document.getElementById('failedReq');
 const failedTok = document.getElementById('failedTok');
+const costTurbo24h = document.getElementById('costTurbo24h');
+const costPlus24h = document.getElementById('costPlus24h');
+const costTotal24h = document.getElementById('costTotal24h');
+const costTurbo7d = document.getElementById('costTurbo7d');
+const costPlus7d = document.getElementById('costPlus7d');
+const costTotal7d = document.getElementById('costTotal7d');
+const costTurbo30d = document.getElementById('costTurbo30d');
+const costPlus30d = document.getElementById('costPlus30d');
+const costTotal30d = document.getElementById('costTotal30d');
+const costCalendar = document.getElementById('costCalendar');
+const toggleCalendar = document.getElementById('toggleCalendar');
 const translateBtn = document.getElementById('translate');
 const testBtn = document.getElementById('test');
 const progressBar = document.getElementById('progress');
@@ -37,6 +48,10 @@ const forceCheckbox = document.getElementById('force');
 const cacheSizeLabel = document.getElementById('cacheSize');
 const cacheLimitInput = document.getElementById('cacheSizeLimit');
 const cacheTTLInput = document.getElementById('cacheTTL');
+
+function formatCost(n) {
+  return '$' + n.toFixed(2);
+}
 
 const applyProviderConfig =
   (window.qwenProviderConfig && window.qwenProviderConfig.applyProviderConfig) ||

--- a/src/transport.js
+++ b/src/transport.js
@@ -1,0 +1,57 @@
+;(function (root) {
+  if (root.qwenTransport) return;
+  var runWithRetry;
+  var approxTokens;
+  var getProvider;
+  if (typeof window === 'undefined') {
+    if (typeof self !== 'undefined' && self.qwenThrottle) {
+      ({ runWithRetry, approxTokens } = self.qwenThrottle);
+    } else {
+      ({ runWithRetry, approxTokens } = require('./throttle'));
+    }
+    if (typeof self !== 'undefined' && self.qwenProviders) {
+      ({ getProvider } = self.qwenProviders);
+    } else {
+      ({ getProvider } = require('./providers'));
+      require('./providers/qwen');
+    }
+  } else {
+    if (window.qwenThrottle) {
+      ({ runWithRetry, approxTokens } = window.qwenThrottle);
+    } else if (typeof require !== 'undefined') {
+      ({ runWithRetry, approxTokens } = require('./throttle'));
+    } else {
+      runWithRetry = fn => fn();
+      approxTokens = () => 0;
+    }
+    if (window.qwenProviders) {
+      ({ getProvider } = window.qwenProviders);
+    } else if (typeof self !== 'undefined' && self.qwenProviders) {
+      ({ getProvider } = self.qwenProviders);
+    } else if (typeof require !== 'undefined') {
+      ({ getProvider } = require('./providers'));
+      require('./providers/qwen');
+    }
+  }
+  async function translate(opts) {
+    const { provider = 'qwen', text, debug, onRetry, retryDelay, onData } = opts;
+    return runWithRetry(
+      () => {
+        const prov = getProvider ? getProvider(provider) : undefined;
+        if (!prov || !prov.translate) throw new Error(`Unknown provider: ${provider}`);
+        return prov.translate({ ...opts, onData });
+      },
+      approxTokens(text),
+      { attempts: opts.attempts, debug, onRetry, retryDelay }
+    );
+  }
+  const api = { translate };
+  if (typeof module !== 'undefined') {
+    module.exports = api;
+  }
+  if (typeof window !== 'undefined') {
+    root.qwenTransport = api;
+  } else if (typeof self !== 'undefined') {
+    root.qwenTransport = api;
+  }
+})(typeof window !== 'undefined' ? window : typeof self !== 'undefined' ? self : globalThis);

--- a/test/translator.test.js
+++ b/test/translator.test.js
@@ -1,3 +1,4 @@
+const transport = require('../src/transport.js');
 const translator = require('../src/translator.js');
 const batch = require('../src/batch.js');
 const {
@@ -7,6 +8,7 @@ const {
   qwenSetCacheLimit,
   qwenSetCacheTTL,
   _setCacheEntryTimestamp,
+  _setGetUsage,
 } = translator;
 const { qwenTranslateBatch, _getTokenBudget, _setTokenBudget } = batch;
 const { configure, reset } = require('../src/throttle');


### PR DESCRIPTION
## Summary
- add dedicated transport module for provider calls with retry and throttling
- load transport in background, content scripts, and tests
- expose cache and usage helpers with model fallback logic

## Testing
- `npm test` *(fails: advanced mode falls back to plus model after 429)*

------
https://chatgpt.com/codex/tasks/task_e_689c2a197f9c8323972d609ba6a2e416