### PR TITLE
Add provider cache Playwright tests and CI hook

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,6 +39,6 @@ jobs:
           fi
 
       - name: Run E2E tests
-        run: npm run test:e2e
+        run: npm run e2e
 
       # Privacy: do not upload screenshots or artifacts by default to avoid exposing PDFs/PII

--- a/e2e/mock.html
+++ b/e2e/mock.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Mock Translation Page</title>
+  <script src="/src/lz-string.min.js"></script>
+  <script src="/src/throttle.js"></script>
+  <script src="/src/cache.js"></script>
+  <script src="/src/providers/index.js"></script>
+  <script src="/src/translator.js"></script>
+  <script src="/src/batch.js"></script>
+  <script>
+    window.qwenProviders.registerProvider('mock', {
+      label: 'Mock',
+      async translate({ text }) {
+        return { text: text + '-fr' };
+      }
+    });
+    window.qwenConfig = { provider: 'mock', sourceLanguage: 'en', targetLanguage: 'fr' };
+  </script>
+</head>
+<body>
+  <p>Mock page for E2E translation tests.</p>
+</body>
+</html>

--- a/e2e/translation-cache.spec.js
+++ b/e2e/translation-cache.spec.js
@@ -1,0 +1,90 @@
+const { test, expect } = require('@playwright/test');
+
+const pageUrl = 'http://127.0.0.1:8080/e2e/mock.html';
+
+test.describe('Provider switching and cache', () => {
+  test('batch translations cache results and support provider change', async ({ page }) => {
+    await page.goto(pageUrl);
+    await page.evaluate(() => {
+      window.qwenProviders.registerProvider('mock2', {
+        async translate({ text }) {
+          return { text: text + '-es' };
+        }
+      });
+    });
+
+    const first = await page.evaluate(() =>
+      window.qwenTranslateBatch({ texts: ['hello'], source: 'en', target: 'fr', provider: 'mock' })
+    );
+    expect(first.texts[0]).toBe('hello-fr');
+
+    const second = await page.evaluate(() =>
+      window.qwenTranslateBatch({ texts: ['hello'], source: 'en', target: 'es', provider: 'mock2' })
+    );
+    expect(second.texts[0]).toBe('hello-es');
+
+    await page.evaluate(() =>
+      window.qwenTranslateBatch({ texts: ['cacheme'], source: 'en', target: 'es', provider: 'mock2' })
+    );
+    await page.reload();
+    const cached = await page.evaluate(async () => {
+      const prov = window.qwenProviders.getProvider('mock2');
+      let calls = 0;
+      const orig = prov.translate;
+      prov.translate = async opts => {
+        calls++;
+        return orig(opts);
+      };
+      const r = await window.qwenTranslateBatch({ texts: ['cacheme'], source: 'en', target: 'es', provider: 'mock2' });
+      return { text: r.texts[0], calls };
+    });
+    expect(cached.text).toBe('cacheme-es');
+    expect(cached.calls).toBe(0);
+
+    const cleared = await page.evaluate(async () => {
+      window.qwenClearCache();
+      const prov = window.qwenProviders.getProvider('mock2');
+      let calls = 0;
+      const orig = prov.translate;
+      prov.translate = async opts => {
+        calls++;
+        return orig(opts);
+      };
+      const r = await window.qwenTranslateBatch({ texts: ['cacheme'], source: 'en', target: 'es', provider: 'mock2' });
+      return { text: r.texts[0], calls };
+    });
+    expect(cleared.text).toBe('cacheme-es');
+    expect(cleared.calls).toBe(1);
+  });
+
+  test('quota warning when provider limit exceeded', async ({ page }) => {
+    await page.goto(pageUrl);
+    await page.evaluate(() => {
+      let count = 0;
+      window.qwenProviders.registerProvider('limited', {
+        async translate({ text }) {
+          count++;
+          if (count > 2) {
+            const err = new Error('quota exceeded');
+            err.retryable = false;
+            throw err;
+          }
+          return { text: text + '-fr' };
+        }
+      });
+    });
+
+    const res = await page.evaluate(async () => {
+      try {
+        await window.qwenTranslate({ provider: 'limited', text: 'a', source: 'en', target: 'fr' });
+        await window.qwenTranslate({ provider: 'limited', text: 'b', source: 'en', target: 'fr' });
+        await window.qwenTranslate({ provider: 'limited', text: 'c', source: 'en', target: 'fr' });
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, msg: e.message };
+      }
+    });
+    expect(res.ok).toBe(false);
+    expect(res.msg).toMatch(/quota exceeded/i);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "jest",
     "build:safari": "bash scripts/convert-safari.sh",
     "test:e2e": "playwright test",
+    "e2e": "playwright test",
     "postinstall": "bash scripts/fetch-wasm-assets.sh"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add mock translation page and Playwright spec validating provider switching, cache persistence, and quota errors
- expose npm `e2e` script and update workflow to run end-to-end suite

## Testing
- `npm test` *(fails: ReferenceError: attempts is not defined; costTurbo24h is not defined)*
- `npm run e2e` *(fails: 2 failing tests; Playwright suite reports provider switching and quota tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_689c2a41202883239fd1b8f58e3af2b1