### PR TITLE
test: expand coverage and e2e scenarios

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Unit Tests
+
+on:
+  push:
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - '.github/workflows/test.yml'
+      - 'package.json'
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - '.github/workflows/test.yml'
+      - 'package.json'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install deps
+        run: npm install --no-audit --no-fund
+      - name: Run unit tests with coverage
+        run: npm test -- --coverage

--- a/e2e/context-menu.spec.js
+++ b/e2e/context-menu.spec.js
@@ -1,0 +1,35 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const pageUrl = 'http://127.0.0.1:8080/e2e/mock.html';
+const contentScript = fs.readFileSync(path.join(__dirname, '../src/contentScript.js'), 'utf8');
+
+test('translates selected text via context menu', async ({ page }) => {
+  await page.goto(pageUrl);
+  await page.addInitScript(() => {
+    window.chrome = {
+      runtime: {
+        getURL: () => 'chrome-extension://abc/',
+        sendMessage: () => {},
+        onMessage: { addListener: cb => { window.__qwenMsg = cb; } }
+      }
+    };
+    window.qwenTranslate = async ({ text }) => ({ text: text + '-fr' });
+    window.qwenTranslateBatch = async ({ texts }) => ({ texts: texts.map(t => t + '-fr') });
+    window.qwenLoadConfig = async () => ({ apiKey: 'k', apiEndpoint: '', model: 'm', sourceLanguage: 'en', targetLanguage: 'fr', provider: 'mock', debug: false });
+  });
+  await page.addScriptTag({ content: contentScript });
+  await page.setContent('<p id="t">hello</p>');
+  await page.evaluate(() => {
+    const el = document.getElementById('t');
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    window.__qwenMsg({ action: 'translate-selection' });
+  });
+  const result = await page.$eval('#t', el => el.textContent);
+  expect(result).toBe('hello-fr');
+});

--- a/e2e/provider-switch.spec.js
+++ b/e2e/provider-switch.spec.js
@@ -1,0 +1,22 @@
+const { test, expect } = require('@playwright/test');
+
+const pageUrl = 'http://127.0.0.1:8080/e2e/mock.html';
+
+test('switches providers for batch translations', async ({ page }) => {
+  await page.goto(pageUrl);
+  await page.evaluate(() => {
+    window.qwenProviders.registerProvider('mock2', {
+      async translate({ text }) {
+        return { text: text + '-es' };
+      }
+    });
+  });
+  const first = await page.evaluate(() =>
+    window.qwenTranslateBatch({ texts: ['hello'], source: 'en', target: 'fr', provider: 'mock' })
+  );
+  expect(first.texts[0]).toBe('hello-fr');
+  const second = await page.evaluate(() =>
+    window.qwenTranslateBatch({ texts: ['hola'], source: 'en', target: 'es', provider: 'mock2' })
+  );
+  expect(second.texts[0]).toBe('hola-es');
+});

--- a/e2e/quota-exhaustion.spec.js
+++ b/e2e/quota-exhaustion.spec.js
@@ -1,0 +1,33 @@
+const { test, expect } = require('@playwright/test');
+
+const pageUrl = 'http://127.0.0.1:8080/e2e/mock.html';
+
+test('surfaces provider quota errors', async ({ page }) => {
+  await page.goto(pageUrl);
+  await page.evaluate(() => {
+    let count = 0;
+    window.qwenProviders.registerProvider('limited', {
+      async translate({ text }) {
+        count++;
+        if (count > 2) {
+          const err = new Error('quota exceeded');
+          err.retryable = false;
+          throw err;
+        }
+        return { text: text + '-fr' };
+      }
+    });
+  });
+  const res = await page.evaluate(async () => {
+    try {
+      await window.qwenTranslate({ provider: 'limited', text: 'a', source: 'en', target: 'fr' });
+      await window.qwenTranslate({ provider: 'limited', text: 'b', source: 'en', target: 'fr' });
+      await window.qwenTranslate({ provider: 'limited', text: 'c', source: 'en', target: 'fr' });
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, msg: e.message };
+    }
+  });
+  expect(res.ok).toBe(false);
+  expect(res.msg).toMatch(/quota exceeded/i);
+});

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -17,6 +17,19 @@ test('evicted entries removed from persistent storage', async () => {
   qwenSetCacheLimit(1000);
 });
 
+test('evicts oldest entry from memory when limit exceeded', async () => {
+  const { cacheReady, setCache, getCache, qwenSetCacheLimit } = require('../src/cache');
+  await cacheReady;
+  qwenSetCacheLimit(2);
+  setCache('a', { text: '1' });
+  setCache('b', { text: '2' });
+  setCache('c', { text: '3' });
+  expect(getCache('a')).toBeUndefined();
+  expect(getCache('b').text).toBe('2');
+  expect(getCache('c').text).toBe('3');
+  qwenSetCacheLimit(1000);
+});
+
 test('prunes expired entries from storage on load', async () => {
   const stale = { text: 'old', ts: Date.now() - 40 * 24 * 60 * 60 * 1000 };
   localStorage.setItem('qwenCache', JSON.stringify({ a: JSON.stringify(stale) }));


### PR DESCRIPTION
## Summary
- add tests for DOM batching, force translation, and cache eviction
- cover provider switching, quota limits, and context menu flows in Playwright
- add CI workflow running `npm test -- --coverage`

## Testing
- `npm test -- --coverage` *(fails: runWithRetry is not a function)*
- `npx playwright test e2e/provider-switch.spec.js e2e/quota-exhaustion.spec.js e2e/context-menu.spec.js` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_689c34fa62248323b3a58470ab30dc03