### PR TITLE
refactor: extract transport and retry helpers

### DIFF
--- a/src/batch.js
+++ b/src/batch.js
@@ -9,6 +9,7 @@
 
   if (typeof window === 'undefined') {
     ({ approxTokens, getUsage } = require('./throttle'));
+    require('./retry');
     ({ cacheReady, getCache, setCache, removeCache } = require('./cache'));
     ({ qwenTranslate } = require('./translator'));
   } else {
@@ -33,6 +34,9 @@
       qwenTranslate = self.qwenTranslate;
     } else if (typeof require !== 'undefined') {
       ({ qwenTranslate } = require('./translator'));
+    }
+    if (!window.qwenRetry && typeof require !== 'undefined') {
+      require('./retry');
     }
   }
 

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -1,5 +1,6 @@
 if (typeof window === 'undefined' && typeof require !== 'undefined') {
   require('./transport');
+  require('./retry');
 }
 if (!location.href.startsWith(chrome.runtime.getURL('pdfViewer.html'))) {
 let observers = [];

--- a/src/retry.js
+++ b/src/retry.js
@@ -1,0 +1,54 @@
+;(function (root) {
+  if (root.qwenRetry) return;
+  var runWithRateLimit;
+  var approxTokens;
+  if (typeof window === 'undefined') {
+    if (typeof self !== 'undefined' && self.qwenThrottle) {
+      ({ runWithRateLimit, approxTokens } = self.qwenThrottle);
+    } else {
+      ({ runWithRateLimit, approxTokens } = require('./throttle'));
+    }
+  } else {
+    if (root.qwenThrottle) {
+      ({ runWithRateLimit, approxTokens } = root.qwenThrottle);
+    } else if (typeof require !== 'undefined') {
+      ({ runWithRateLimit, approxTokens } = require('./throttle'));
+    } else {
+      runWithRateLimit = fn => fn();
+      approxTokens = () => 0;
+    }
+  }
+
+  function delay(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  async function runWithRetry(fn, text, opts = {}) {
+    const tokens = typeof text === 'number' ? text : approxTokens(text || '');
+    const { attempts = 6, debug = false, onRetry, retryDelay = 500 } = opts;
+    let wait = retryDelay;
+    for (let i = 0; i < attempts; i++) {
+      try {
+        if (debug) console.log('QTDEBUG: attempt', i + 1);
+        return await runWithRateLimit(fn, tokens);
+      } catch (err) {
+        if (!err.retryable || i === attempts - 1) throw err;
+        const delayMs = err.retryAfter || wait;
+        if (onRetry) onRetry({ attempt: i + 1, delayMs, error: err });
+        if (debug) console.log('QTDEBUG: retrying after error', err.message);
+        await delay(delayMs);
+        wait = delayMs * 2;
+      }
+    }
+  }
+
+  const api = { runWithRetry };
+  if (typeof module !== 'undefined') {
+    module.exports = api;
+  }
+  if (typeof window !== 'undefined') {
+    root.qwenRetry = api;
+  } else if (typeof self !== 'undefined') {
+    root.qwenRetry = api;
+  }
+})(typeof window !== 'undefined' ? window : typeof self !== 'undefined' ? self : globalThis);

--- a/src/translator.js
+++ b/src/translator.js
@@ -1,8 +1,4 @@
-var runWithRateLimit;
-var runWithRetry;
-var approxTokens;
-var getUsage;
-var getProvider;
+var transportTranslate;
 var cacheReady;
 var getCache;
 var setCache;
@@ -15,7 +11,6 @@ var qwenGetCompressionErrors;
 var _setMaxCacheEntries;
 var _setCacheTTL;
 var _setCacheEntryTimestamp;
-var LZString;
 
 if (typeof window === 'undefined') {
   if (typeof self !== 'undefined' && self.qwenTransport) {
@@ -23,56 +18,31 @@ if (typeof window === 'undefined') {
   } else {
     ({ translate: transportTranslate } = require('./transport'));
   }
-  if (typeof self !== 'undefined' && self.qwenThrottle) {
-    ({ runWithRateLimit, runWithRetry, approxTokens, getUsage } = self.qwenThrottle);
-    ({ cacheReady, getCache, setCache, removeCache, qwenClearCache, qwenGetCacheSize, qwenGetCompressionErrors, qwenSetCacheLimit, qwenSetCacheTTL, _setMaxCacheEntries, _setCacheTTL, _setCacheEntryTimestamp } = require('./cache'));
-    LZString = require('lz-string');
-    ({ getProvider } = require('./providers'));
-    require('./providers/qwen');
-  } else {
-    ({ runWithRateLimit, runWithRetry, approxTokens, getUsage } = require('./throttle'));
-    ({ cacheReady, getCache, setCache, removeCache, qwenClearCache, qwenGetCacheSize, qwenGetCompressionErrors, qwenSetCacheLimit, qwenSetCacheTTL, _setMaxCacheEntries, _setCacheTTL, _setCacheEntryTimestamp } = require('./cache'));
-    LZString = require('lz-string');
-    ({ getProvider } = require('./providers'));
-    require('./providers/qwen');
-  }
-  ({ cacheReady, getCache, setCache, removeCache, qwenClearCache, qwenGetCacheSize, qwenSetCacheLimit, qwenSetCacheTTL, _setMaxCacheEntries, _setCacheTTL, _setCacheEntryTimestamp } = require('./cache'));
-  LZString = require('lz-string');
+  ({ cacheReady, getCache, setCache, removeCache, qwenClearCache, qwenGetCacheSize, qwenGetCompressionErrors, qwenSetCacheLimit, qwenSetCacheTTL, _setMaxCacheEntries, _setCacheTTL, _setCacheEntryTimestamp } = require('./cache'));
 } else {
   if (window.qwenTransport) {
     ({ translate: transportTranslate } = window.qwenTransport);
   } else if (typeof require !== 'undefined') {
     ({ translate: transportTranslate } = require('./transport'));
-  } else {
-    runWithRateLimit = fn => fn();
-    runWithRetry = fn => fn();
-    approxTokens = () => 0;
-    getUsage = () => ({ requestLimit: 1, tokenLimit: 1, requests: 0, tokens: 0 });
   }
-  LZString = (typeof window !== 'undefined' ? window.LZString : undefined) ||
-    (typeof self !== 'undefined' ? self.LZString : undefined) ||
-    (typeof require !== 'undefined' ? require('lz-string') : undefined);
-  if (typeof window !== 'undefined' && window.qwenCache) {
+  if (window.qwenCache) {
     ({ cacheReady, getCache, setCache, removeCache, qwenClearCache, qwenGetCacheSize, qwenGetCompressionErrors, qwenSetCacheLimit, qwenSetCacheTTL, _setMaxCacheEntries, _setCacheTTL, _setCacheEntryTimestamp } = window.qwenCache);
   } else if (typeof self !== 'undefined' && self.qwenCache) {
     ({ cacheReady, getCache, setCache, removeCache, qwenClearCache, qwenGetCacheSize, qwenGetCompressionErrors, qwenSetCacheLimit, qwenSetCacheTTL, _setMaxCacheEntries, _setCacheTTL, _setCacheEntryTimestamp } = self.qwenCache);
   } else if (typeof require !== 'undefined') {
     ({ cacheReady, getCache, setCache, removeCache, qwenClearCache, qwenGetCacheSize, qwenGetCompressionErrors, qwenSetCacheLimit, qwenSetCacheTTL, _setMaxCacheEntries, _setCacheTTL, _setCacheEntryTimestamp } = require('./cache'));
   }
-  if (typeof window !== 'undefined' && window.qwenProviders) {
-    ({ getProvider } = window.qwenProviders);
-  } else if (typeof self !== 'undefined' && self.qwenProviders) {
-    ({ getProvider } = self.qwenProviders);
-  } else if (typeof require !== 'undefined' && !getProvider) {
-    ({ getProvider } = require('./providers'));
-    require('./providers/qwen');
-  }
 }
 
 async function qwenTranslate({ provider = 'qwen', endpoint, apiKey, model, text, source, target, signal, debug = false, stream = false, noProxy = false, onRetry, retryDelay, force = false }) {
   await cacheReady;
+  const modelList =
+    typeof models === 'undefined'
+      ? [model]
+      : Array.isArray(models)
+      ? models
+      : [models];
   if (debug) {
-    const modelList = Array.isArray(models) ? models : models ? [models] : [model];
     console.log('QTDEBUG: qwenTranslate called with', {
       provider,
       endpoint,
@@ -130,21 +100,27 @@ async function qwenTranslate({ provider = 'qwen', endpoint, apiKey, model, text,
 
   try {
     const attempts = 3;
-    const data = await runWithRetry(
-      () => {
-        const prov = getProvider ? getProvider(provider) : undefined;
-        if (!prov || !prov.translate) throw new Error(`Unknown provider: ${provider}`);
-        return prov.translate({ endpoint, apiKey, model, text, source, target, signal, debug, stream });
-      },
-      approxTokens(text),
-      { attempts, debug, onRetry, retryDelay }
-    );
+    const data = await transportTranslate({
+      provider,
+      endpoint,
+      apiKey,
+      model,
+      text,
+      source,
+      target,
+      signal,
+      debug,
+      stream,
+      onRetry,
+      retryDelay,
+      attempts,
+    });
     setCache(cacheKey, data);
     if (debug) {
       console.log('QTDEBUG: translation successful');
       console.log('QTDEBUG: final text', data.text);
-
     }
+    return data;
   } catch (e) {
     if (modelList && modelList.length > 1 && model === modelList[0]) {
       try {
@@ -162,7 +138,7 @@ async function qwenTranslate({ provider = 'qwen', endpoint, apiKey, model, text,
           stream,
           onRetry,
           retryDelay,
-          attempts,
+          attempts: 3,
         });
         setCache(cacheKey, data);
         return data;
@@ -178,8 +154,13 @@ async function qwenTranslate({ provider = 'qwen', endpoint, apiKey, model, text,
 
 async function qwenTranslateStream({ provider = 'qwen', endpoint, apiKey, model, text, source, target, signal, debug = false, stream = true, noProxy = false, onRetry, retryDelay, force = false }, onData) {
   await cacheReady;
+  const modelList =
+    typeof models === 'undefined'
+      ? [model]
+      : Array.isArray(models)
+      ? models
+      : [models];
   if (debug) {
-    const modelList = Array.isArray(models) ? models : models ? [models] : [model];
     console.log('QTDEBUG: qwenTranslateStream called with', {
       endpoint,
       apiKeySet: Boolean(apiKey),
@@ -199,15 +180,22 @@ async function qwenTranslateStream({ provider = 'qwen', endpoint, apiKey, model,
   }
   try {
     const attempts = 3;
-    const data = await runWithRetry(
-      () => {
-        const prov = getProvider ? getProvider(provider) : undefined;
-        if (!prov || !prov.translate) throw new Error(`Unknown provider: ${provider}`);
-        return prov.translate({ endpoint, apiKey, model, text, source, target, signal, debug, onData, stream });
-      },
-      approxTokens(text),
-      { attempts, debug, onRetry, retryDelay }
-    );
+    const data = await transportTranslate({
+      provider,
+      endpoint,
+      apiKey,
+      model,
+      text,
+      source,
+      target,
+      signal,
+      debug,
+      stream,
+      onRetry,
+      retryDelay,
+      attempts,
+      onData,
+    });
     setCache(cacheKey, data);
     if (debug) {
       console.log('QTDEBUG: translation successful');

--- a/src/transport.js
+++ b/src/transport.js
@@ -1,13 +1,12 @@
 ;(function (root) {
   if (root.qwenTransport) return;
   var runWithRetry;
-  var approxTokens;
   var getProvider;
   if (typeof window === 'undefined') {
-    if (typeof self !== 'undefined' && self.qwenThrottle) {
-      ({ runWithRetry, approxTokens } = self.qwenThrottle);
+    if (typeof self !== 'undefined' && self.qwenRetry) {
+      ({ runWithRetry } = self.qwenRetry);
     } else {
-      ({ runWithRetry, approxTokens } = require('./throttle'));
+      ({ runWithRetry } = require('./retry'));
     }
     if (typeof self !== 'undefined' && self.qwenProviders) {
       ({ getProvider } = self.qwenProviders);
@@ -16,16 +15,15 @@
       require('./providers/qwen');
     }
   } else {
-    if (window.qwenThrottle) {
-      ({ runWithRetry, approxTokens } = window.qwenThrottle);
+    if (root.qwenRetry) {
+      ({ runWithRetry } = root.qwenRetry);
     } else if (typeof require !== 'undefined') {
-      ({ runWithRetry, approxTokens } = require('./throttle'));
+      ({ runWithRetry } = require('./retry'));
     } else {
       runWithRetry = fn => fn();
-      approxTokens = () => 0;
     }
-    if (window.qwenProviders) {
-      ({ getProvider } = window.qwenProviders);
+    if (root.qwenProviders) {
+      ({ getProvider } = root.qwenProviders);
     } else if (typeof self !== 'undefined' && self.qwenProviders) {
       ({ getProvider } = self.qwenProviders);
     } else if (typeof require !== 'undefined') {
@@ -41,7 +39,7 @@
         if (!prov || !prov.translate) throw new Error(`Unknown provider: ${provider}`);
         return prov.translate({ ...opts, onData });
       },
-      approxTokens(text),
+      text,
       { attempts: opts.attempts, debug, onRetry, retryDelay }
     );
   }

--- a/test/throttle.test.js
+++ b/test/throttle.test.js
@@ -1,4 +1,4 @@
-const { runWithRateLimit, runWithRetry, configure, getUsage } = require('../src/throttle');
+const { runWithRateLimit, configure, getUsage } = require('../src/throttle');
 
 jest.useFakeTimers();
 


### PR DESCRIPTION
## Summary
- move retry logic into new `retry.js`
- shift provider transport to use retry helper and slim down `translator.js`
- update batch, content script, and throttle tests to new module structure

## Testing
- `npm test` *(popupCost.test.js, popupCache.test.js failed: Cannot set properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_689c34f9b5348323a035d4054b27608e