### PR TITLE
Add provider tests and extend cost tracking coverage

### DIFF
--- a/src/providers/deepl.js
+++ b/src/providers/deepl.js
@@ -1,0 +1,39 @@
+let fetchFn = typeof fetch !== 'undefined' ? fetch : undefined;
+if (typeof window === 'undefined' && typeof fetchFn === 'undefined' && typeof require !== 'undefined') {
+  fetchFn = require('cross-fetch');
+}
+function withSlash(url) {
+  return url.endsWith('/') ? url : url + '/';
+}
+async function translate({ endpoint, apiKey, model, text, source, target, signal, debug }) {
+  const url = `${withSlash(endpoint)}v2/translate`;
+  const params = new URLSearchParams();
+  params.append('text', text);
+  if (source) params.append('source_lang', source.toUpperCase());
+  if (target) params.append('target_lang', target.toUpperCase());
+  if (model) params.append('model', model);
+  if (debug) console.log('QTDEBUG: DeepL request', params.toString());
+  const headers = { 'Content-Type': 'application/x-www-form-urlencoded' };
+  const key = (apiKey || '').trim();
+  if (key)
+    headers.Authorization = /^DeepL-Auth-Key\s/i.test(key)
+      ? key
+      : `DeepL-Auth-Key ${key}`;
+  const resp = await fetchFn(url, {
+    method: 'POST',
+    headers,
+    body: params.toString(),
+    signal,
+  });
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({ message: resp.statusText }));
+    throw new Error(err.message || `HTTP ${resp.status}`);
+  }
+  const data = await resp.json();
+  const t = data.translations?.[0]?.text;
+  if (!t) throw new Error('Invalid API response');
+  return { text: t };
+}
+const { registerProvider } = require('./index');
+registerProvider('deepl', { translate, label: 'DeepL', configFields: ['apiKey', 'apiEndpoint', 'model'] });
+module.exports = { translate };

--- a/src/providers/google.js
+++ b/src/providers/google.js
@@ -1,0 +1,33 @@
+let fetchFn = typeof fetch !== 'undefined' ? fetch : undefined;
+if (typeof window === 'undefined' && typeof fetchFn === 'undefined' && typeof require !== 'undefined') {
+  fetchFn = require('cross-fetch');
+}
+function withSlash(url) {
+  return url.endsWith('/') ? url : url + '/';
+}
+async function translate({ endpoint, apiKey, model, text, source, target, signal, debug }) {
+  const url = `${withSlash(endpoint)}language/translate/v2`;
+  if (debug) console.log('QTDEBUG: Google request', { model, text, source, target });
+  const body = { q: text, source, target, format: 'text' };
+  if (model) body.model = model;
+  const headers = { 'Content-Type': 'application/json' };
+  const key = (apiKey || '').trim();
+  if (key) headers.Authorization = /^Bearer\s/i.test(key) ? key : `Bearer ${key}`;
+  const resp = await fetchFn(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+    signal,
+  });
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({ message: resp.statusText }));
+    throw new Error(err.error?.message || err.message || `HTTP ${resp.status}`);
+  }
+  const data = await resp.json();
+  const t = data.data?.translations?.[0]?.translatedText;
+  if (!t) throw new Error('Invalid API response');
+  return { text: t };
+}
+const { registerProvider } = require('./index');
+registerProvider('google', { translate, label: 'Google', configFields: ['apiKey', 'apiEndpoint', 'model'] });
+module.exports = { translate };

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -160,6 +160,14 @@ describe('background cost tracking', () => {
     const res = await new Promise(resolve => usageListener({ action: 'usage' }, null, resolve));
     expect(res.costs['qwen-mt-turbo']['24h']).toBeCloseTo(0);
     expect(res.costs['qwen-mt-plus']['24h']).toBeCloseTo(0.03686);
-    expect(res.costs.total['7d']).toBeCloseTo(0.038);
+    expect(res.costs['qwen-mt-turbo']['7d']).toBeCloseTo(0.00114);
+    expect(res.costs['qwen-mt-plus']['7d']).toBeCloseTo(0.03686);
+    expect(res.costs.total['7d']).toBeCloseTo(
+      res.costs['qwen-mt-turbo']['7d'] + res.costs['qwen-mt-plus']['7d']
+    );
+    const day1 = res.costs.daily.find(d => d.date === '2024-01-01');
+    const day2 = res.costs.daily.find(d => d.date === '2024-01-02');
+    expect(day1.cost).toBeCloseTo(0.00114);
+    expect(day2.cost).toBeCloseTo(0.03686);
   });
 });

--- a/test/deepl.provider.test.js
+++ b/test/deepl.provider.test.js
@@ -1,0 +1,24 @@
+const fetchMock = require('jest-fetch-mock');
+beforeAll(() => fetchMock.enableMocks());
+beforeEach(() => fetch.resetMocks());
+
+describe('deepl provider', () => {
+  const { translate } = require('../src/providers/deepl');
+  test('sends request and parses response', async () => {
+    fetch.mockResponseOnce(
+      JSON.stringify({ translations: [{ text: 'hola' }] })
+    );
+    const res = await translate({
+      endpoint: 'https://d/',
+      apiKey: 'k',
+      text: 'hello',
+      source: 'en',
+      target: 'es',
+    });
+    expect(res.text).toBe('hola');
+    const [url, opts] = fetch.mock.calls[0];
+    expect(url).toBe('https://d/v2/translate');
+    expect(opts.headers.Authorization).toBe('DeepL-Auth-Key k');
+    expect(opts.body).toBe('text=hello&source_lang=EN&target_lang=ES');
+  });
+});

--- a/test/google.provider.test.js
+++ b/test/google.provider.test.js
@@ -1,0 +1,31 @@
+const fetchMock = require('jest-fetch-mock');
+beforeAll(() => fetchMock.enableMocks());
+beforeEach(() => fetch.resetMocks());
+
+describe('google provider', () => {
+  const { translate } = require('../src/providers/google');
+  test('sends request and parses response', async () => {
+    fetch.mockResponseOnce(
+      JSON.stringify({ data: { translations: [{ translatedText: 'hola' }] } })
+    );
+    const res = await translate({
+      endpoint: 'https://g/',
+      apiKey: 'k',
+      model: 'nmt',
+      text: 'hello',
+      source: 'en',
+      target: 'es',
+    });
+    expect(res.text).toBe('hola');
+    const [url, opts] = fetch.mock.calls[0];
+    expect(url).toBe('https://g/language/translate/v2');
+    expect(JSON.parse(opts.body)).toEqual({
+      q: 'hello',
+      source: 'en',
+      target: 'es',
+      format: 'text',
+      model: 'nmt',
+    });
+    expect(opts.headers.Authorization).toBe('Bearer k');
+  });
+});

--- a/test/popupCache.test.js
+++ b/test/popupCache.test.js
@@ -6,7 +6,7 @@ describe('popup cache controls', () => {
     document.body.innerHTML = '';
     document.getElementById = id => document.querySelector('#' + id);
     [
-      'source','target','auto','debug','smartThrottle','dualMode','translate','test','clearCache','clearDomain','clearPair','toggleCalendar','provider','setup-provider',
+      'source','target','auto','debug','smartThrottle','dualMode','translate','test','clearCache','clearDomain','clearPair','toggleCalendar','provider','setup-provider','reqRemaining','tokenRemaining','providerError','reqRemainingBar','tokenRemainingBar',
       'cacheSize','hitRate','costTurbo24h','costPlus24h','costTotal24h','costTurbo7d','costPlus7d','costTotal7d','costTurbo30d','costPlus30d','costTotal30d',
       'status','domainCounts','costCalendar','progress'
     ].forEach(id => {

--- a/test/popupCost.test.js
+++ b/test/popupCost.test.js
@@ -6,7 +6,7 @@ describe('popup cost display', () => {
     document.getElementById = id => document.querySelector('#' + id);
     [
       'apiKey','apiEndpoint','model','requestLimit','tokenLimit','tokenBudget','tokensPerReq','retryDelay','setup-apiKey','setup-apiEndpoint','setup-model','provider','setup-provider',
-      'source','target','auto','debug','smartThrottle','dualMode','translate','test','clearCache','clearDomain','clearPair','toggleCalendar',
+      'source','target','auto','debug','smartThrottle','dualMode','translate','test','clearCache','clearDomain','clearPair','toggleCalendar','reqRemaining','tokenRemaining','providerError','reqRemainingBar','tokenRemainingBar',
       'cacheSize','hitRate','costTurbo24h','costPlus24h','costTotal24h','costTurbo7d','costPlus7d','costTotal7d','costTurbo30d','costPlus30d','costTotal30d',
       'domainCounts','status','costCalendar','progress'
     ].forEach(id => {

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -1,12 +1,18 @@
 const { registerProvider, listProviders } = require('../src/providers');
 require('../src/providers/qwen');
+require('../src/providers/google');
+require('../src/providers/deepl');
 
 test('listProviders returns name and label', () => {
   const mock = { translate: jest.fn(), label: 'Mock Provider' };
   registerProvider('mock', mock);
   const list = listProviders();
-  expect(list).toEqual(expect.arrayContaining([
-    { name: 'qwen', label: 'Qwen' },
-    { name: 'mock', label: 'Mock Provider' },
-  ]));
+  expect(list).toEqual(
+    expect.arrayContaining([
+      { name: 'qwen', label: 'Qwen' },
+      { name: 'google', label: 'Google' },
+      { name: 'deepl', label: 'DeepL' },
+      { name: 'mock', label: 'Mock Provider' },
+    ])
+  );
 });

--- a/test/translator.test.js
+++ b/test/translator.test.js
@@ -1,3 +1,7 @@
+const fetchMock = require('jest-fetch-mock');
+const throttle = require('../src/throttle');
+const { runWithRetry } = require('../src/retry');
+global.qwenThrottle = { ...throttle, runWithRetry };
 const transport = require('../src/transport.js');
 const translator = require('../src/translator.js');
 const batch = require('../src/batch.js');
@@ -11,9 +15,8 @@ const {
   _setGetUsage,
 } = translator;
 const { qwenTranslateBatch, _getTokenBudget, _setTokenBudget } = batch;
-const { configure, reset } = require('../src/throttle');
+const { configure, reset } = throttle;
 const { modelTokenLimits } = require('../src/config');
-const fetchMock = require('jest-fetch-mock');
 const { registerProvider } = require('../src/providers');
 
 beforeAll(() => { fetchMock.enableMocks(); });
@@ -425,3 +428,19 @@ test('retries after 429 with backoff', async () => {
 });
 
 
+
+test('chooses secondary model when usage high', async () => {
+  const mock = { translate: jest.fn().mockResolvedValue({ text: 'x' }) };
+  registerProvider('mocklb', mock);
+  _setGetUsage(() => ({ requestLimit: 100, requests: 60 }));
+  await translate({
+    provider: 'mocklb',
+    endpoint: 'https://e/',
+    apiKey: 'k',
+    models: ['m1', 'm2'],
+    text: 'hi',
+    source: 'en',
+    target: 'es',
+  });
+  expect(mock.translate).toHaveBeenCalledWith(expect.objectContaining({ model: 'm2' }));
+});


### PR DESCRIPTION
## Summary
- add Google and DeepL providers with request handling
- test provider payloads and parsing for Google and DeepL
- extend tests for provider registry, cost aggregation, and load balancing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c406cb16c83239253a9d897ea27f9