### PR TITLE
feat: support extended provider config fields

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -3,54 +3,176 @@ const modelTokenLimits = {
   'qwen-mt-plus': 23797,
 };
 
-const defaultCfg = {
-  apiKey: '',
-  apiEndpoint: 'https://dashscope-intl.aliyuncs.com/api/v1',
-  model: 'qwen-mt-turbo',
-  sourceLanguage: 'en',
-  targetLanguage: 'en',
-  autoTranslate: false,
-  provider: 'qwen',
-  requestLimit: 60,
-  tokenLimit: modelTokenLimits['qwen-mt-turbo'],
-  tokenBudget: 0,
-  remainingRequests: 0,
-  remainingTokens: 0,
-  providerError: '',
-  quotaHistory: [],
-  smartThrottle: true,
-  tokensPerReq: 0,
-  retryDelay: 0,
-  debug: false,
-  dualMode: false,
-  useWasmEngine: true,
-  autoOpenAfterSave: true,
-  cacheMaxEntries: 1000,
-  cacheTTL: 30 * 24 * 60 * 60 * 1000,
+const defaultProviders = {
+  qwen: {
+    apiKey: '',
+    endpoint: 'https://dashscope-intl.aliyuncs.com/api/v1',
+    model: 'qwen-mt-turbo',
+    projectId: '',
+    location: '',
+    documentModel: '',
+  },
+  google: {
+    apiKey: '',
+    endpoint: '',
+    model: '',
+    projectId: '',
+    location: '',
+    documentModel: '',
+  },
+  deeplFree: {
+    apiKey: '',
+    endpoint: '',
+    model: '',
+    projectId: '',
+    location: '',
+    documentModel: '',
+  },
+  deeplPro: {
+    apiKey: '',
+    endpoint: '',
+    model: '',
+    projectId: '',
+    location: '',
+    documentModel: '',
+  },
 };
+
+function getDefaultCfg() {
+  return {
+    apiKey: '',
+    apiEndpoint: 'https://dashscope-intl.aliyuncs.com/api/v1',
+    model: 'qwen-mt-turbo',
+    projectId: '',
+    location: '',
+    documentModel: '',
+    sourceLanguage: 'en',
+    targetLanguage: 'en',
+    autoTranslate: false,
+    provider: 'qwen',
+    requestLimit: 60,
+    tokenLimit: modelTokenLimits['qwen-mt-turbo'],
+    tokenBudget: 0,
+    remainingRequests: 0,
+    remainingTokens: 0,
+    providerError: '',
+    quotaHistory: [],
+    smartThrottle: true,
+    tokensPerReq: 0,
+    retryDelay: 0,
+    debug: false,
+    dualMode: false,
+    useWasmEngine: true,
+    autoOpenAfterSave: true,
+    cacheMaxEntries: 1000,
+    cacheTTL: 30 * 24 * 60 * 60 * 1000,
+    providers: {
+      qwen: { ...defaultProviders.qwen },
+      google: { ...defaultProviders.google },
+      deeplFree: { ...defaultProviders.deeplFree },
+      deeplPro: { ...defaultProviders.deeplPro },
+    },
+  };
+}
+
+const defaultCfg = getDefaultCfg();
+
+function migrateConfig(cfg) {
+  const out = { ...getDefaultCfg(), ...cfg };
+  let needsSave = false;
+
+  out.providers = {
+    qwen: { ...defaultProviders.qwen, ...(cfg.providers && cfg.providers.qwen) },
+    google: { ...defaultProviders.google, ...(cfg.providers && cfg.providers.google) },
+    deeplFree: { ...defaultProviders.deeplFree, ...(cfg.providers && cfg.providers.deeplFree) },
+    deeplPro: { ...defaultProviders.deeplPro, ...(cfg.providers && cfg.providers.deeplPro) },
+  };
+
+  if (!cfg.providers) needsSave = true;
+
+  if (cfg.apiKey && !out.providers.qwen.apiKey) {
+    out.providers.qwen.apiKey = cfg.apiKey;
+    needsSave = true;
+  }
+  if (cfg.apiEndpoint && !out.providers.qwen.endpoint) {
+    out.providers.qwen.endpoint = cfg.apiEndpoint;
+    needsSave = true;
+  }
+  if (cfg.model && !out.providers.qwen.model) {
+    out.providers.qwen.model = cfg.model;
+    needsSave = true;
+  }
+  if (cfg.projectId && !out.providers.qwen.projectId) {
+    out.providers.qwen.projectId = cfg.projectId;
+    needsSave = true;
+  }
+  if (cfg.location && !out.providers.qwen.location) {
+    out.providers.qwen.location = cfg.location;
+    needsSave = true;
+  }
+  if (cfg.documentModel && !out.providers.qwen.documentModel) {
+    out.providers.qwen.documentModel = cfg.documentModel;
+    needsSave = true;
+  }
+
+  const active = out.providers[out.provider] || out.providers.qwen;
+  out.apiKey = active.apiKey || '';
+  out.apiEndpoint = active.endpoint || '';
+  out.model = active.model || '';
+  out.projectId = active.projectId || '';
+  out.location = active.location || '';
+  out.documentModel = active.documentModel || '';
+
+  return { cfg: out, needsSave };
+}
 
 function qwenLoadConfig() {
   // For local testing (pdfViewer.html), prioritize window.qwenConfig
   if (typeof window !== 'undefined' && window.qwenConfig) {
-    return Promise.resolve({ ...defaultCfg, ...window.qwenConfig });
+    const { cfg } = migrateConfig(window.qwenConfig);
+    return Promise.resolve(cfg);
   }
 
   // For the Chrome extension
   if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.sync) {
     return new Promise((resolve) => {
-      chrome.storage.sync.get(defaultCfg, (cfg) => resolve(cfg));
+      chrome.storage.sync.get(getDefaultCfg(), async (cfg) => {
+        const { cfg: mCfg, needsSave } = migrateConfig(cfg);
+        if (needsSave) await qwenSaveConfig(mCfg);
+        resolve(mCfg);
+      });
     });
   }
 
   // Fallback for other environments (like Node.js for jest tests)
-  return Promise.resolve(defaultCfg);
+  const { cfg } = migrateConfig({});
+  return Promise.resolve(cfg);
 }
 
 function qwenSaveConfig(cfg) {
+  const { cfg: out } = migrateConfig(cfg);
+  const p = out.provider || 'qwen';
+  out.providers[p] = {
+    ...out.providers[p],
+    apiKey: cfg.apiKey || '',
+    endpoint: cfg.apiEndpoint || '',
+    model: cfg.model || '',
+    projectId: cfg.projectId || '',
+    location: cfg.location || '',
+    documentModel: cfg.documentModel || '',
+  };
+  const active = out.providers[p];
+  out.apiKey = active.apiKey;
+  out.apiEndpoint = active.endpoint;
+  out.model = active.model;
+  out.projectId = active.projectId;
+  out.location = active.location;
+  out.documentModel = active.documentModel;
+
   // Only save if in the Chrome extension context
   if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.sync) {
     return new Promise((resolve) => {
-      chrome.storage.sync.set(cfg, resolve);
+      chrome.storage.sync.set(out, resolve);
     });
   }
   return Promise.resolve(); // Otherwise, do nothing

--- a/src/popup.js
+++ b/src/popup.js
@@ -51,6 +51,11 @@ const cacheLimitInput = document.getElementById('cacheSizeLimit');
 const cacheTTLInput = document.getElementById('cacheTTL');
 const clearDomainBtn = document.getElementById('clearDomain');
 const clearPairBtn = document.getElementById('clearPair');
+const reqRemaining = document.getElementById('reqRemaining');
+const tokenRemaining = document.getElementById('tokenRemaining');
+const reqRemainingBar = document.getElementById('reqRemainingBar');
+const tokenRemainingBar = document.getElementById('tokenRemainingBar');
+const providerError = document.getElementById('providerError');
 
 if (sourceSelect && !sourceSelect.options.length) {
   ['en', 'fr'].forEach(v => {

--- a/src/providerConfig.js
+++ b/src/providerConfig.js
@@ -1,6 +1,13 @@
 function applyProviderConfig(provider, doc = document) {
   const fields = (provider && provider.configFields) || ['apiKey', 'apiEndpoint', 'model'];
-  const all = ['apiKey', 'apiEndpoint', 'model'];
+  const all = [
+    'apiKey',
+    'apiEndpoint',
+    'model',
+    'projectId',
+    'location',
+    'documentModel',
+  ];
   all.forEach(name => {
     const show = fields.includes(name);
     doc.querySelectorAll(`[data-field="${name}"]`).forEach(el => {

--- a/src/translator.js
+++ b/src/translator.js
@@ -49,6 +49,16 @@ if (typeof window === 'undefined') {
   } else if (typeof require !== 'undefined') {
     ({ runWithRateLimit, runWithRetry, approxTokens, getUsage } = require('./throttle'));
   }
+
+  if (!runWithRetry) {
+    if (typeof window !== 'undefined' && window.qwenRetry) {
+      ({ runWithRetry } = window.qwenRetry);
+    } else if (typeof self !== 'undefined' && self.qwenRetry) {
+      ({ runWithRetry } = self.qwenRetry);
+    } else if (typeof require !== 'undefined') {
+      ({ runWithRetry } = require('./retry'));
+    }
+  }
 }
 
 async function qwenTranslate({ provider = 'qwen', endpoint, apiKey, model, models, text, source, target, signal, debug = false, stream = false, noProxy = false, onRetry, retryDelay, force = false }) {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,27 @@
+describe('config migration', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    delete global.chrome;
+  });
+
+  test('migrates flat config to providers', async () => {
+    const stored = { apiKey: 'k', apiEndpoint: 'https://e/', model: 'm', provider: 'qwen' };
+    const set = jest.fn((o, cb) => cb && cb());
+    global.chrome = { storage: { sync: { get: (d, cb) => cb({ ...d, ...stored }), set } } };
+    const { qwenLoadConfig } = require('../src/config.js');
+    const cfg = await qwenLoadConfig();
+    expect(cfg.providers.qwen.apiKey).toBe('k');
+    expect(cfg.apiKey).toBe('k');
+    expect(set).toHaveBeenCalled();
+  });
+
+  test('saves provider specific fields', async () => {
+    const set = jest.fn((o, cb) => cb && cb());
+    global.chrome = { storage: { sync: { set } } };
+    const { qwenSaveConfig } = require('../src/config.js');
+    await qwenSaveConfig({ provider: 'google', apiKey: 'g', apiEndpoint: 'https://g/', model: 'gm', providers: {} });
+    const saved = set.mock.calls[0][0];
+    expect(saved.providers.google.apiKey).toBe('g');
+    expect(saved.apiKey).toBe('g');
+  });
+});

--- a/test/providerConfig.test.js
+++ b/test/providerConfig.test.js
@@ -5,12 +5,25 @@ test('hides unused fields based on provider config', () => {
     <label data-field="apiKey"></label><input data-field="apiKey">
     <label data-field="apiEndpoint"></label><input data-field="apiEndpoint">
     <label data-field="model"></label><select data-field="model"></select>
+    <label data-field="projectId"></label><input data-field="projectId">
+    <label data-field="location"></label><input data-field="location">
+    <label data-field="documentModel"></label><input data-field="documentModel">
   `;
   const provider = { configFields: ['apiKey'] };
   applyProviderConfig(provider, document);
   expect(document.querySelector('[data-field="apiKey"]').style.display).toBe('');
-  document.querySelectorAll('[data-field="apiEndpoint"], [data-field="model"]').forEach(el => {
-    expect(el.style.display).toBe('none');
-  });
+  document
+    .querySelectorAll(
+      [
+        '[data-field="apiEndpoint"]',
+        '[data-field="model"]',
+        '[data-field="projectId"]',
+        '[data-field="location"]',
+        '[data-field="documentModel"]',
+      ].join(', ')
+    )
+    .forEach(el => {
+      expect(el.style.display).toBe('none');
+    });
 });
 


### PR DESCRIPTION
## Summary
- handle project-specific fields in provider configuration
- test provider config for the new fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c4043c0fc832387a9066a3b51b298