### PR TITLE
Add DOM streaming translation e2e tests

### DIFF
--- a/e2e/dom-translate.spec.js
+++ b/e2e/dom-translate.spec.js
@@ -1,0 +1,71 @@
+const { test, expect } = require('@playwright/test');
+
+const pageUrl = 'http://127.0.0.1:8080/e2e/mock.html';
+
+test.describe('DOM translation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(pageUrl);
+    await page.evaluate(() => {
+      window.qwenProviders.registerProvider('stream', {
+        async translate({ text, onData, signal }) {
+          const final = 'Bonjour';
+          const chunks = ['Bon', 'jour'];
+          for (const chunk of chunks) {
+            if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+            await new Promise(r => setTimeout(r, 100));
+            if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+            if (onData) onData(chunk);
+          }
+          return { text: final };
+        }
+      });
+    });
+  });
+
+  test('streams translation and preserves layout', async ({ page }) => {
+    const p = page.locator('p');
+    const before = await p.boundingBox();
+    await page.evaluate(async () => {
+      const el = document.querySelector('p');
+      const orig = el.textContent;
+      el.textContent = '';
+      await window.qwenTranslateStream({ provider: 'stream', text: orig, source: 'en', target: 'fr', stream: true }, chunk => {
+        el.textContent += chunk;
+      });
+    });
+    await page.waitForFunction(() => document.querySelector('p').textContent === 'Bonjour');
+    const after = await p.boundingBox();
+    expect(after.x).toBeCloseTo(before.x, 1);
+    expect(after.y).toBeCloseTo(before.y, 1);
+    const txt = await p.textContent();
+    expect(txt).toBe('Bonjour');
+  });
+
+  test('cancels streaming translation and keeps original text', async ({ page }) => {
+    const p = page.locator('p');
+    const before = await p.boundingBox();
+    await page.evaluate(() => {
+      window.controller = new AbortController();
+      const el = document.querySelector('p');
+      window.originalText = el.textContent;
+      el.textContent = '';
+      window.promise = window.qwenTranslateStream(
+        { provider: 'stream', text: window.originalText, source: 'en', target: 'fr', stream: true, signal: window.controller.signal },
+        chunk => { el.textContent += chunk; }
+      ).catch(e => {
+        el.textContent = window.originalText;
+        return e.name;
+      });
+    });
+    await page.waitForFunction(() => document.querySelector('p').textContent.length > 0);
+    await page.evaluate(() => window.controller.abort());
+    const res = await page.evaluate(() => window.promise);
+    expect(res).toBe('AbortError');
+    const after = await p.boundingBox();
+    expect(after.x).toBeCloseTo(before.x, 1);
+    expect(after.y).toBeCloseTo(before.y, 1);
+    const txt = await p.textContent();
+    expect(txt).toBe('Mock page for E2E translation tests.');
+  });
+});
+

--- a/e2e/mock.html
+++ b/e2e/mock.html
@@ -6,7 +6,14 @@
   <script src="/src/lz-string.min.js"></script>
   <script src="/src/throttle.js"></script>
   <script src="/src/cache.js"></script>
-  <script src="/src/providers/index.js"></script>
+  <script src="/src/lib/providers.js"></script>
+  <script>
+    window.qwenProviders.registerProvider = window.qwenProviders.register;
+    window.qwenProviders.getProvider = window.qwenProviders.get;
+    window.qwenProviders.initProviders = window.qwenProviders.init;
+    window.qwenProviders.ensureProviders = window.qwenProviders.init;
+    window.qwenProviders.resetProviders = window.qwenProviders.reset;
+  </script>
   <script src="/src/translator.js"></script>
   <script src="/src/batch.js"></script>
   <script>
@@ -16,6 +23,7 @@
         return { text: text + '-fr' };
       }
     });
+    window.qwenProviders.initProviders();
     window.qwenConfig = { provider: 'mock', sourceLanguage: 'en', targetLanguage: 'fr' };
   </script>
 </head>

--- a/src/providers/deepl.js
+++ b/src/providers/deepl.js
@@ -4,7 +4,7 @@
   else root.qwenProviderDeepL = mod;
 }(typeof self !== 'undefined' ? self : this, function (root) {
   const fetchFn = (typeof fetch !== 'undefined') ? fetch : (root.fetch || null);
-  function withSlash(u) { return /\/$/.test(u) ? u : u + '/'; }
+    function withSlash(u) { return /\/$/.test(u) ? u : u + '/'; }
 
   async function translate({ endpoint = 'https://api.deepl.com/', apiKey, text, source, target, signal, debug }) {
     if (!fetchFn) throw new Error('fetch not available');
@@ -46,23 +46,19 @@
     return { text: out, characters };
   }
 
-  function makeProvider(ep) {
-    return {
-      translate: opts => translate({ ...opts, endpoint: ep || opts.endpoint }),
-      label: 'DeepL',
-      configFields: ['apiKey', 'apiEndpoint', 'model'],
-    };
-  }
+    function makeProvider(ep) {
+      return {
+        translate: opts => translate({ ...opts, endpoint: ep || opts.endpoint }),
+        label: 'DeepL',
+        configFields: ['apiKey', 'apiEndpoint', 'model'],
+        throttle: { requestLimit: 15, windowMs: 1000 },
+      };
+    }
 
-function makeProvider(ep) {
-  return {
-    translate: opts => translate({ ...opts, endpoint: ep || opts.endpoint }),
-    label: 'DeepL',
-    configFields: ['apiKey', 'apiEndpoint', 'model'],
-    throttle: { requestLimit: 15, windowMs: 1000 },
-  };
-}
+    const basic = makeProvider('https://api-free.deepl.com/');
+    const free = makeProvider('https://api-free.deepl.com/');
+    const pro = makeProvider('https://api.deepl.com/');
 
-  return { translate, basic, free, pro };
-}));
+    return { translate, basic, free, pro };
+  }));
 


### PR DESCRIPTION
## Summary
- add Playwright tests for DOM translation covering streaming and cancellation
- restore DeepL provider exports and ensure e2e mock page initializes provider registry

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689f5d0f6b188323a2ef01fc89096045