### PR TITLE
Add compact and light mode toggles to popup

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,8 @@ const defaultCfg = {
   debug: false,
   useWasmEngine: true,
   autoOpenAfterSave: true,
+  compact: false,
+  theme: 'dark',
   providers: {},
 };
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -67,12 +67,8 @@
     .bar > div { height: 100%; width: 0%; transition: width 0.2s ease-in-out, background-color 0.2s ease-in-out; }
     .form-group { display: flex; flex-direction: column; gap: 0.5rem; }
     label { font-size: 0.875rem; }
-    input[type=text], input[type=number], select { width: 100%; box-sizing: border-box; padding: 0.5rem 0.75rem; border: 1px solid var(--input-border); border-radius: 6px; background-color: var(--input-bg); color: var(--text-color); font-size: 1rem; }
-    input:focus, select:focus { outline: none; border-color: var(--input-focus-border); box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25); }
-    button { padding: 0.6rem 1rem; border: none; border-radius: 6px; background-color: var(--primary-color); color: #fff; font-weight: 600; cursor: pointer; transition: background-color 0.15s ease-in-out; }
-    button:hover { background-color: var(--primary-hover-color); }
-    button#test { background-color: var(--secondary-bg); color: var(--text-color); }
-    button#test:hover { background-color: var(--secondary-hover-bg); }
+    .view-options { display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; }
+    .view-options label { display: flex; align-items: center; gap: 0.25rem; }
     #status { font-size: 0.875rem; min-height: 40px; max-height: 150px; overflow-y: auto; border: 1px solid var(--input-border); padding: 0.5rem; background-color: var(--input-bg); border-radius: 6px; white-space: pre-wrap; }
     #version { font-size: 0.75rem; text-align: center; opacity: 0.7; }
     .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; }
@@ -86,7 +82,7 @@
     }
   </style>
 </head>
-<body>
+<body class="qwen-bg-animated">
   <div id="viewContainer" class="view-container">
     <!-- ===== SETUP VIEW ===== -->
     <div class="setup-view">
@@ -108,7 +104,7 @@
     <!-- ===== MAIN VIEW ===== -->
     <div class="main-view">
       <div class="main-actions">
-        <button id="translate" title="Translate the current tab">Translate Page</button>
+        <button id="translate" class="primary-glow" title="Translate the current tab">Translate Page</button>
         <div class="auto-translate-toggle">
           <label class="switch">
             <input type="checkbox" id="auto">
@@ -116,6 +112,11 @@
           </label>
           <span title="Automatically translate supported pages as they load. You can still click Translate Page to force refresh.">Auto</span>
         </div>
+      </div>
+
+      <div class="view-options">
+        <label title="Compact layout"><input type="checkbox" id="compactMode"> Compact</label>
+        <label title="Light theme"><input type="checkbox" id="lightMode"> Light</label>
       </div>
 
       <details open id="usageDetails">
@@ -217,7 +218,7 @@
         </div>
       </details>
 
-      <button id="test">Test Settings</button>
+      <button id="test" class="secondary">Test Settings</button>
       <progress id="progress" value="0" max="1" style="width:100%;display:none"></progress>
       <div id="status"></div>
       <div id="version"></div>

--- a/src/popup.js
+++ b/src/popup.js
@@ -9,6 +9,8 @@ const tokenLimitInput = document.getElementById('tokenLimit') || document.create
 const tokenBudgetInput = document.getElementById('tokenBudget') || document.createElement('input');
 const autoCheckbox = document.getElementById('auto') || document.createElement('input');
 const debugCheckbox = document.getElementById('debug') || document.createElement('input');
+const compactCheckbox = document.getElementById('compactMode') || document.createElement('input');
+const lightModeCheckbox = document.getElementById('lightMode') || document.createElement('input');
 const detectorSelect = document.getElementById('detector') || document.createElement('select');
 const detectApiKeyInput = document.getElementById('detectApiKey') || document.createElement('input');
 const status = document.getElementById('status') || document.createElement('div');
@@ -26,6 +28,9 @@ const testBtn = document.getElementById('test') || document.createElement('butto
 const progressBar = document.getElementById('progress') || document.createElement('progress');
 const providerPreset = document.getElementById('providerPreset') || document.createElement('select');
 const clearPairBtn = document.getElementById('clearPair') || document.createElement('button');
+
+document.body.classList.add('qwen-bg-animated');
+if (translateBtn) translateBtn.classList.add('primary-glow');
 
 // Setup view elements
 const setupApiKeyInput = document.getElementById('setup-apiKey') || document.createElement('input');
@@ -56,6 +61,8 @@ function saveConfig() {
       tokenBudget: parseInt(tokenBudgetInput.value, 10) || 0,
       autoTranslate: autoCheckbox.checked,
       debug: debugCheckbox.checked,
+      compact: compactCheckbox.checked,
+      theme: lightModeCheckbox.checked ? 'light' : 'dark',
     };
     window.qwenSaveConfig(cfg).then(() => {
       status.textContent = 'Settings saved.';
@@ -211,6 +218,10 @@ window.qwenLoadConfig().then(cfg => {
   tokenBudgetInput.value = cfg.tokenBudget || '';
   autoCheckbox.checked = cfg.autoTranslate;
   debugCheckbox.checked = !!cfg.debug;
+  compactCheckbox.checked = !!cfg.compact;
+  document.body.classList.toggle('qwen-compact', compactCheckbox.checked);
+  lightModeCheckbox.checked = cfg.theme === 'light';
+  document.documentElement.setAttribute('data-qwen-color', lightModeCheckbox.checked ? 'light' : 'dark');
 
   // Populate setup view
   setupApiKeyInput.value = cfg.apiKey || '';
@@ -239,6 +250,14 @@ window.qwenLoadConfig().then(cfg => {
 
   [reqLimitInput, tokenLimitInput, tokenBudgetInput].forEach(el => el.addEventListener('input', saveConfig));
   [sourceSelect, targetSelect, autoCheckbox, debugCheckbox].forEach(el => el.addEventListener('change', saveConfig));
+  compactCheckbox.addEventListener('change', () => {
+    document.body.classList.toggle('qwen-compact', compactCheckbox.checked);
+    saveConfig();
+  });
+  lightModeCheckbox.addEventListener('change', () => {
+    document.documentElement.setAttribute('data-qwen-color', lightModeCheckbox.checked ? 'light' : 'dark');
+    saveConfig();
+  });
   // If user turns on Auto, request permission and start on current tab immediately
   autoCheckbox.addEventListener('change', () => {
     if (!autoCheckbox.checked) return;

--- a/src/popup/dom.js
+++ b/src/popup/dom.js
@@ -10,6 +10,8 @@ const dom = {
   tokenBudgetInput: document.getElementById('tokenBudget'),
   autoCheckbox: document.getElementById('auto'),
   debugCheckbox: document.getElementById('debug'),
+  compactCheckbox: document.getElementById('compactMode'),
+  lightModeCheckbox: document.getElementById('lightMode'),
   smartThrottleInput: document.getElementById('smartThrottle'),
   tokensPerReqInput: document.getElementById('tokensPerReq'),
   retryDelayInput: document.getElementById('retryDelay'),

--- a/src/styles/cyberpunk.css
+++ b/src/styles/cyberpunk.css
@@ -5,6 +5,112 @@
   --qwen-neon-2: #ff00e5;
   --qwen-border: rgba(0, 229, 255, 0.4);
   --qwen-error: #ff3b81;
+  --qwen-input-bg: rgba(0, 0, 0, 0.2);
+  --qwen-input-focus: var(--qwen-neon-1);
+  --qwen-primary-bg: var(--qwen-neon-1);
+  --qwen-primary-hover: var(--qwen-neon-2);
+  --qwen-secondary-bg: rgba(0, 0, 0, 0.35);
+  --qwen-secondary-hover: rgba(0, 0, 0, 0.55);
+}
+
+:root[data-qwen-theme="cyberpunk"][data-qwen-color="light"] {
+  --qwen-bg: rgba(250, 250, 255, 0.9);
+  --qwen-text: #001018;
+  --qwen-input-bg: rgba(255, 255, 255, 0.8);
+  --qwen-secondary-bg: rgba(255, 255, 255, 0.7);
+  --qwen-secondary-hover: rgba(255, 255, 255, 0.9);
+}
+
+[data-qwen-theme="cyberpunk"] input[type="text"],
+[data-qwen-theme="cyberpunk"] input[type="number"],
+[data-qwen-theme="cyberpunk"] select {
+  box-sizing: border-box;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--qwen-border);
+  border-radius: 6px;
+  background: var(--qwen-input-bg);
+  color: var(--qwen-text);
+  font-size: 1rem;
+}
+
+[data-qwen-theme="cyberpunk"] input:focus,
+[data-qwen-theme="cyberpunk"] select:focus {
+  outline: none;
+  border-color: var(--qwen-input-focus);
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+}
+
+[data-qwen-theme="cyberpunk"] input[type="checkbox"] {
+  accent-color: var(--qwen-neon-1);
+}
+
+[data-qwen-theme="cyberpunk"] button {
+  padding: 0.6rem 1rem;
+  border: none;
+  border-radius: 6px;
+  background: var(--qwen-primary-bg);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.15s ease-in-out;
+}
+
+[data-qwen-theme="cyberpunk"] button:hover {
+  background: var(--qwen-primary-hover);
+}
+
+[data-qwen-theme="cyberpunk"] button.secondary {
+  background: var(--qwen-secondary-bg);
+  color: var(--qwen-text);
+}
+
+[data-qwen-theme="cyberpunk"] button.secondary:hover {
+  background: var(--qwen-secondary-hover);
+}
+
+body.qwen-compact {
+  --body-width: 320px;
+  gap: 0.5rem;
+}
+
+body.qwen-bg-animated::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    repeating-linear-gradient(
+      0deg,
+      transparent 0,
+      transparent 10px,
+      rgba(0, 229, 255, 0.03) 10px,
+      rgba(0, 229, 255, 0.03) 11px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      transparent 0,
+      transparent 10px,
+      rgba(255, 0, 229, 0.03) 10px,
+      rgba(255, 0, 229, 0.03) 11px
+    );
+  background-size: 100px 100px;
+  animation: qwen-grid-move 30s linear infinite;
+  z-index: -1;
+}
+
+[data-qwen-theme="cyberpunk"] button.primary-glow {
+  box-shadow: 0 0 8px var(--qwen-neon-1), 0 0 16px var(--qwen-neon-1);
+  animation: qwen-pulse 3s ease-in-out infinite;
+}
+
+@keyframes qwen-grid-move {
+  from { background-position: 0 0, 0 0; }
+  to { background-position: 100px 100px, -100px -100px; }
+}
+
+@keyframes qwen-pulse {
+  0%, 100% { box-shadow: 0 0 8px var(--qwen-neon-1), 0 0 16px var(--qwen-neon-1); }
+  50% { box-shadow: 0 0 12px var(--qwen-neon-2), 0 0 24px var(--qwen-neon-2); }
 }
 
 .qwen-hud {
@@ -97,4 +203,15 @@
 
 @media (prefers-reduced-motion: reduce) {
   .qwen-hud::after { animation: none; opacity: 0.25; }
+  [data-qwen-theme="cyberpunk"] button,
+  [data-qwen-theme="cyberpunk"] button:hover,
+  [data-qwen-theme="cyberpunk"] .slider,
+  [data-qwen-theme="cyberpunk"] .slider:before,
+  [data-qwen-theme="cyberpunk"] .bar > div {
+    transition: none !important;
+  }
+  body.qwen-bg-animated::before,
+  [data-qwen-theme="cyberpunk"] button.primary-glow {
+    animation: none !important;
+  }
 }

--- a/test/popup.test.js
+++ b/test/popup.test.js
@@ -10,7 +10,10 @@ describe('popup configuration test', () => {
       <select id="target"></select>
       <select id="detector"></select>
       <input id="debug" type="checkbox" />
+      <input id="compactMode" type="checkbox" />
+      <input id="lightMode" type="checkbox" />
       <div id="status"></div>
+      <button id="translate"></button>
       <button id="test"></button>
     `;
     global.qwenLanguages = [
@@ -29,6 +32,8 @@ describe('popup configuration test', () => {
       autoTranslate: false,
       detector: 'local',
       debug: true,
+      compact: false,
+      theme: 'dark',
     });
     global.qwenSaveConfig = jest.fn().mockResolvedValue();
     global.qwenTranslate = jest.fn().mockResolvedValue({ text: 'hola' });
@@ -92,6 +97,21 @@ describe('popup configuration test', () => {
     expect(entries.some(e => e.ns === 'popup' && e.level === 'info' && e.args[0] === 'diagnostic step started')).toBe(true);
     expect(global.qwenTranslate.mock.calls.some(c => c[0].noProxy === true)).toBe(true);
     remove();
+  });
+
+  test('toggles compact and light modes', async () => {
+    require('../src/popup.js');
+    await Promise.resolve();
+    expect(document.body.classList.contains('qwen-bg-animated')).toBe(true);
+    expect(document.getElementById('translate').classList.contains('primary-glow')).toBe(true);
+    const compact = document.getElementById('compactMode');
+    compact.checked = true;
+    compact.dispatchEvent(new Event('change'));
+    expect(document.body.classList.contains('qwen-compact')).toBe(true);
+    const light = document.getElementById('lightMode');
+    light.checked = true;
+    light.dispatchEvent(new Event('change'));
+    expect(document.documentElement.getAttribute('data-qwen-color')).toBe('light');
   });
 });
 


### PR DESCRIPTION
## Summary
- theme inputs and buttons in cyberpunk stylesheet, including light mode and reduced-motion
- add compact layout and light mode toggles in popup, persisting to config
- animate popup with neon grid background and pulsing translate button
- test new popup modes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f7269f5348323b598e6104305d3e9