### PR TITLE
feat: add stop controls and polish popup ui

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -357,6 +357,14 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       self.qwenConfig = self.qwenConfig || {};
       self.qwenConfig.memCacheMax = c.memCacheMax;
     }
+    if (typeof c.requestLimit === 'number' || typeof c.tokenLimit === 'number') {
+      ensureThrottle().then(() => {
+        const opts = {};
+        if (typeof c.requestLimit === 'number') opts.requestLimit = c.requestLimit;
+        if (typeof c.tokenLimit === 'number') opts.tokenLimit = c.tokenLimit;
+        self.qwenThrottle.configure(opts);
+      });
+    }
     sendResponse({ ok: true });
     return true;
   }

--- a/src/popup.html
+++ b/src/popup.html
@@ -26,7 +26,7 @@
       width: var(--body-width);
       padding: 1rem;
       margin: 0;
-      background-color: var(--bg-color);
+      background: var(--bg-color) url('styles/popup-bg.svg') center/cover no-repeat;
       color: var(--text-color);
       display: flex;
       flex-direction: column;
@@ -72,6 +72,7 @@
     #status { font-size: 0.875rem; min-height: 40px; max-height: 150px; overflow-y: auto; border: 1px solid var(--input-border); padding: 0.5rem; background-color: var(--input-bg); border-radius: 6px; white-space: pre-wrap; }
     #version { font-size: 0.75rem; text-align: center; opacity: 0.7; }
     .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; }
+    .grid-2 > * { min-width: 0; }
     summary { cursor: pointer; font-weight: 600; }
     #usageDetails { padding: 0.25rem 0.5rem; background: var(--secondary-bg); border-radius: 8px; }
     #usageDetails summary { list-style: none; }

--- a/src/styles/cyberpunk.css
+++ b/src/styles/cyberpunk.css
@@ -1,4 +1,4 @@
-:root[data-qwen-theme="cyberpunk"] {
+[data-qwen-theme="cyberpunk"] {
   --qwen-bg: rgba(8, 10, 20, 0.65);
   --qwen-text: #e6f7ff;
   --qwen-neon-1: #00e5ff;
@@ -7,13 +7,13 @@
   --qwen-error: #ff3b81;
   --qwen-input-bg: rgba(0, 0, 0, 0.2);
   --qwen-input-focus: var(--qwen-neon-1);
-  --qwen-primary-bg: var(--qwen-neon-1);
+  --qwen-primary-bg: #008ab3;
   --qwen-primary-hover: var(--qwen-neon-2);
   --qwen-secondary-bg: rgba(0, 0, 0, 0.35);
   --qwen-secondary-hover: rgba(0, 0, 0, 0.55);
 }
 
-:root[data-qwen-theme="cyberpunk"][data-qwen-color="light"] {
+[data-qwen-theme="cyberpunk"][data-qwen-color="light"] {
   --qwen-bg: rgba(250, 250, 255, 0.9);
   --qwen-text: #001018;
   --qwen-input-bg: rgba(255, 255, 255, 0.8);
@@ -31,6 +31,8 @@
   background: var(--qwen-input-bg);
   color: var(--qwen-text);
   font-size: 1rem;
+  width: 100%;
+  max-width: 100%;
 }
 
 [data-qwen-theme="cyberpunk"] input:focus,
@@ -45,14 +47,32 @@
 }
 
 [data-qwen-theme="cyberpunk"] button {
+  position: relative;
   padding: 0.6rem 1rem;
-  border: none;
+  border: 1px solid var(--qwen-border);
   border-radius: 6px;
-  background: var(--qwen-primary-bg);
-  color: #fff;
+  background: var(--qwen-secondary-bg);
+  color: var(--qwen-text);
   font-weight: 600;
   cursor: pointer;
+  overflow: hidden;
   transition: background-color 0.15s ease-in-out;
+}
+
+[data-qwen-theme="cyberpunk"] button::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 6px;
+  border: 1px solid var(--qwen-neon-1);
+  box-shadow: 0 0 6px var(--qwen-neon-1), 0 0 12px var(--qwen-neon-2);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease-in-out;
+}
+
+[data-qwen-theme="cyberpunk"] button:hover::after {
+  opacity: 1;
 }
 
 [data-qwen-theme="cyberpunk"] button:hover {
@@ -61,7 +81,6 @@
 
 [data-qwen-theme="cyberpunk"] button.secondary {
   background: var(--qwen-secondary-bg);
-  color: var(--qwen-text);
 }
 
 [data-qwen-theme="cyberpunk"] button.secondary:hover {
@@ -99,8 +118,14 @@ body.qwen-bg-animated::before {
 }
 
 [data-qwen-theme="cyberpunk"] button.primary-glow {
+  background: linear-gradient(90deg, var(--qwen-neon-1), var(--qwen-neon-2));
+  color: #000;
   box-shadow: 0 0 8px var(--qwen-neon-1), 0 0 16px var(--qwen-neon-1);
   animation: qwen-pulse 3s ease-in-out infinite;
+}
+
+[data-qwen-theme="cyberpunk"] button.primary-glow::after {
+  display: none;
 }
 
 @keyframes qwen-grid-move {
@@ -205,6 +230,7 @@ body.qwen-bg-animated::before {
   .qwen-hud::after { animation: none; opacity: 0.25; }
   [data-qwen-theme="cyberpunk"] button,
   [data-qwen-theme="cyberpunk"] button:hover,
+  [data-qwen-theme="cyberpunk"] button::after,
   [data-qwen-theme="cyberpunk"] .slider,
   [data-qwen-theme="cyberpunk"] .slider:before,
   [data-qwen-theme="cyberpunk"] .bar > div {

--- a/src/styles/popup-bg.svg
+++ b/src/styles/popup-bg.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="600">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#081018"/>
+      <stop offset="100%" stop-color="#0a0c14"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="600" fill="url(#bg)"/>
+  <g stroke="#00e5ff" stroke-opacity="0.15" stroke-width="1">
+    <path d="M0 50h400 M0 100h400 M0 150h400 M0 200h400 M0 250h400 M0 300h400 M0 350h400 M0 400h400 M0 450h400 M0 500h400 M0 550h400"/>
+    <path d="M50 0v600 M100 0v600 M150 0v600 M200 0v600 M250 0v600 M300 0v600 M350 0v600"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- allow active translations to be stopped and auto-toggle cancels running jobs
- fix rate limit bars by updating throttle config and handling missing limits
- add neon grid popup background and redesigned cyberpunk buttons

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_689f7e0760d88323909c2ec210f137f1