### PR TITLE
feat: add typings for messaging and TM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Type check
+        run: npm run typecheck
+
       - name: Run unit tests
         run: npm test -- --ci --reporters=default
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "jest-fetch-mock": "^3.0.3",
         "lz-string": "^1.5.0",
         "pdf-lib": "^1.17.1",
-        "rimraf": "^5.0.5"
+        "rimraf": "^5.0.5",
+        "typescript": "^5.4.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7027,6 +7028,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build": "npm run clean && copyfiles -u 1 src/**/* dist",
     "zip": "bestzip dist/qwen-translator-v$npm_package_version.zip dist/*",
     "build:zip": "npm run build && npm run zip",
-    "serve": "http-server dist -p 8080"
+    "serve": "http-server dist -p 8080",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",
@@ -32,7 +33,8 @@
     "pdf-lib": "^1.17.1",
     "bestzip": "^2.2.1",
     "copyfiles": "^2.4.1",
-    "rimraf": "^5.0.5"
+    "rimraf": "^5.0.5",
+    "typescript": "^5.4.5"
   },
   "dependencies": {
     "mupdf": "^1.26.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["types/**/*.d.ts"]
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -41,14 +41,11 @@ export declare function qwenTranslate(opts: TranslateOptions): Promise<{ text: s
 export declare function qwenTranslateStream(opts: TranslateOptions, onData: (chunk: string) => void): Promise<{ text: string }>
 export declare function qwenTranslateBatch(opts: BatchOptions): Promise<{ texts: string[] }>
 export declare function qwenClearCache(): void;
-export declare const qwenProviders: {
-  registerProvider(id: string, impl: any): void;
-  getProvider(id: string): any;
-  listProviders(): { name: string; label: string }[];
-  initProviders(): void;
-  isInitialized(): boolean;
-};
 export declare const qwenFetchStrategy: {
   choose(opts?: { noProxy?: boolean }): 'proxy' | 'direct';
   setChooser(fn?: (opts?: any) => 'proxy' | 'direct'): void;
 };
+
+export * from './providers';
+export * from './messaging';
+export * from './tm';

--- a/types/messaging.d.ts
+++ b/types/messaging.d.ts
@@ -1,0 +1,30 @@
+export interface BackgroundRequestOptions {
+  endpoint?: string;
+  apiKey?: string;
+  model?: string;
+  text: string;
+  source?: string;
+  target: string;
+  debug?: boolean;
+  stream?: boolean;
+  signal?: AbortSignal;
+  onData?: (chunk: string) => void;
+  provider?: string;
+  providerOrder?: string[];
+  endpoints?: Record<string, string>;
+}
+
+export interface DetectOptions {
+  text: string;
+  detector?: string;
+  debug?: boolean;
+  sensitivity?: number;
+}
+
+export declare function requestViaBackground(opts: BackgroundRequestOptions): Promise<{ text: string }>;
+export declare function detectLanguage(opts: DetectOptions): Promise<{ lang: string; confidence?: number }>;
+
+export declare const qwenMessaging: {
+  requestViaBackground: typeof requestViaBackground;
+  detectLanguage: typeof detectLanguage;
+};

--- a/types/providers.d.ts
+++ b/types/providers.d.ts
@@ -1,0 +1,22 @@
+export interface ProvidersRegistry {
+  register(id: string, impl: any): void;
+  get(id: string): any;
+  choose(opts?: { endpoint?: string; provider?: string }): string;
+  candidates(opts?: { endpoint?: string; provider?: string }): string[];
+  init(def?: Record<string, any>): boolean;
+  reset(): void;
+  isInitialized(): boolean;
+}
+
+export interface ProvidersApi {
+  registerProvider(id: string, impl: any): void;
+  getProvider(id: string): any;
+  listProviders(): { name: string; label: string }[];
+  initProviders(): void;
+  ensureProviders(): boolean;
+  resetProviders(): void;
+  isInitialized(): boolean;
+  createRegistry(): ProvidersRegistry;
+}
+
+export declare const qwenProviders: ProvidersApi;

--- a/types/tm.d.ts
+++ b/types/tm.d.ts
@@ -1,0 +1,26 @@
+export interface TMEntry {
+  k: string;
+  text: string;
+  ts: number;
+}
+
+export interface TMStats {
+  hits: number;
+  misses: number;
+  sets: number;
+  evictionsTTL: number;
+  evictionsLRU: number;
+  entries: number;
+}
+
+export declare function get(key: string): Promise<TMEntry | null>;
+export declare function set(key: string, text: string): Promise<void>;
+export declare function stats(): TMStats;
+export declare function __resetStats(): void;
+
+export declare const qwenTM: {
+  get: typeof get;
+  set: typeof set;
+  stats: typeof stats;
+  __resetStats: typeof __resetStats;
+};


### PR DESCRIPTION
## Summary
- add TypeScript declarations for providers, messaging, and translation memory modules
- expose new declarations via the package index and tsconfig
- enable `npm run typecheck` in CI

## Testing
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f8ae696348323aabd678d44d6d827