### PR TITLE
refactor: group popup settings into collapsible sections

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -67,6 +67,7 @@
     .bar > div { height: 100%; width: 0%; transition: width 0.2s ease-in-out, background-color 0.2s ease-in-out; }
     .form-group { display: flex; flex-direction: column; gap: 0.5rem; }
     label { font-size: 0.875rem; }
+    .help { font-size: 0.75rem; opacity: 0.8; }
     .view-options { display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; }
     .view-options label { display: flex; align-items: center; gap: 0.25rem; }
     #status { font-size: 0.875rem; min-height: 40px; max-height: 150px; overflow-y: auto; border: 1px solid var(--input-border); padding: 0.5rem; background-color: var(--input-bg); border-radius: 6px; white-space: pre-wrap; }
@@ -166,20 +167,23 @@
         </ul>
       </details>
 
-      <details>
-        <summary>Advanced Settings</summary>
+      <details id="providerSection">
+        <summary>Provider</summary>
         <div class="form-group" style="padding-top: 0.75rem">
           <label for="apiKey">API Key</label>
           <input type="text" id="apiKey" placeholder="Enter your API key"
                  title="Your provider API key. Stored only in browser storage and used by the background. Never injected into pages.">
+          <small class="help">Authenticates requests. Required for translation.</small>
 
           <label for="apiEndpoint">API Endpoint</label>
           <input type="text" id="apiEndpoint" placeholder="e.g., https://dashscope-intl.aliyuncs.com/api/v1"
                  title="Base URL for your provider API (https://.../). A trailing slash is added automatically if omitted.">
+          <small class="help">Base URL for API calls, typically ending with /api/v1.</small>
 
           <label for="model">Model</label>
           <input type="text" id="model" placeholder="e.g., qwen-mt-turbo"
                  title="Provider model identifier (e.g., qwen-mt-turbo, gpt-4o-mini).">
+          <small class="help">Translation model name. Higher-tier models cost more.</small>
 
           <label for="providerPreset">Provider preset</label>
           <select id="providerPreset" title="Pick a preset to auto‑fill endpoint and a typical model. Paste your API key separately.">
@@ -189,43 +193,67 @@
             <option value="openrouter">OpenRouter</option>
             <option value="deepl">DeepL</option>
           </select>
+          <small class="help">Auto-fills endpoint and model; still paste your own key.</small>
+        </div>
+      </details>
 
+      <details id="detectionSection">
+        <summary>Detection</summary>
+        <div class="form-group" style="padding-top: 0.75rem">
           <label for="detector">Detector</label>
           <select id="detector" title="How to detect the source language when Source is auto. Local is private and free. Google requires a Detection API key.">
             <option value="local">Local (on-device)</option>
             <option value="google">Google (Cloud)</option>
           </select>
+          <small class="help">Local is free; Google improves accuracy but needs a key.</small>
 
           <label for="detectApiKey">Detection API Key (Google)</label>
           <input type="text" id="detectApiKey" placeholder="Only needed for Google detector"
                  title="Google Cloud API key used only for language detection. Create a key and enable the Cloud Translation API.">
+          <small class="help">Required only when using Google detector.</small>
 
           <label for="sensitivity">Detection sensitivity</label>
           <input type="number" id="sensitivity" min="0" max="1" step="0.1"
                  title="Minimum confidence (0-1) required for detection to apply.">
+          <small class="help">Higher values need stronger signal. 0.2–0.6 typical.</small>
+        </div>
+      </details>
 
+      <details id="rateSection">
+        <summary>Rate Limits</summary>
+        <div class="form-group" style="padding-top: 0.75rem">
           <div class="grid-2">
             <div>
               <label for="requestLimit">Requests/min</label>
               <input type="number" id="requestLimit" title="Maximum requests per minute. The extension throttles to stay under limits.">
+              <small class="help">Throttle requests per minute; 60 typical.</small>
             </div>
             <div>
               <label for="tokenLimit">Tokens/min</label>
               <input type="number" id="tokenLimit" title="Maximum tokens per minute. Adjust to match your provider quota.">
+              <small class="help">Match provider quota, e.g., 100000.</small>
             </div>
           </div>
 
           <label for="tokenBudget">Token budget</label>
           <input type="number" id="tokenBudget" placeholder="auto"
                  title="Max tokens per batch request. Leave blank for auto‑calibration.">
+          <small class="help">Max tokens per request. Leave blank for auto; 1000–5000 common.</small>
+        </div>
+      </details>
 
+      <details id="cacheSection">
+      <summary>Cache &amp; Debug</summary>
+        <div class="form-group" style="padding-top: 0.75rem">
           <label for="memCacheMax">Memory cache max</label>
           <input type="number" id="memCacheMax" placeholder="5000"
                  title="Maximum entries for in‑memory translation cache.">
+          <small class="help">Entries kept in RAM; 1000–10000 typical.</small>
           <div id="cacheStats" style="font-size:0.75rem"></div>
           <div id="tmStats" style="font-size:0.75rem"></div>
 
           <label title="Enable detailed logs for troubleshooting in DevTools."><input type="checkbox" id="debug"> Debug logging</label>
+          <small class="help">Logs extra info to DevTools; slight performance hit.</small>
         </div>
       </details>
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -33,10 +33,33 @@ const progressBar = document.getElementById('progress') || document.createElemen
 const providerPreset = document.getElementById('providerPreset') || document.createElement('select');
 const clearPairBtn = document.getElementById('clearPair') || document.createElement('button');
 
+// Collapsible sections
+const sectionIds = ['providerSection', 'detectionSection', 'rateSection', 'cacheSection'];
+
 document.body.classList.add('qwen-bg-animated');
 if (translateBtn) translateBtn.classList.add('primary-glow');
 
 let translating = false;
+
+function initSectionToggles() {
+  if (typeof chrome === 'undefined' || !chrome.storage || !chrome.storage.sync) return;
+  chrome.storage.sync.get({ openSections: {} }, ({ openSections }) => {
+    sectionIds.forEach(id => {
+      const el = document.getElementById(id);
+      if (!el) return;
+      if (openSections[id]) el.open = true;
+      el.addEventListener('toggle', () => {
+        chrome.storage.sync.get({ openSections: {} }, data => {
+          const store = data.openSections || {};
+          if (el.open) store[id] = true; else delete store[id];
+          chrome.storage.sync.set({ openSections: store });
+        });
+      });
+    });
+  });
+}
+
+initSectionToggles();
 
 // Setup view elements
 const setupApiKeyInput = document.getElementById('setup-apiKey') || document.createElement('input');


### PR DESCRIPTION
## Summary
- Split popup advanced settings into collapsible Provider, Detection, Rate Limits, and Cache & Debug sections with helper text
- Persist open state for new sections in popup.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f9b4e789c8323961c9d6293fb4d0b