### PR TITLE
Expose background stats in popup

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -133,16 +133,25 @@
             <div class="bar"><div id="tokenBar"></div></div>
           </div>
           <div class="usage-item">Total Requests: <span id="totalReq">0</span></div>
-          <div class="usage-item">Total Tokens: <span id="totalTok">0</span></div>
-          <div class="usage-item">Queue: <span id="queueLen">0</span></div>
-        </div>
-        <div id="costSection"></div>
-      </details>
+        <div class="usage-item">Total Tokens: <span id="totalTok">0</span></div>
+        <div class="usage-item">Queue: <span id="queueLen">0</span></div>
+      </div>
+      <div id="costSection"></div>
+    </details>
 
-      <div class="grid-2">
-        <div>
-          <label for="source">Source Language</label>
-          <select id="source" title="Language to translate from. Use 'Auto-detect' for convenience and mixed-language pages."></select>
+    <details id="statsDetails" open>
+      <summary>Stats</summary>
+      <div class="usage-section">
+        <div class="usage-item">Requests: <span id="statsRequests">0</span></div>
+        <div class="usage-item">Tokens: <span id="statsTokens">0</span></div>
+        <div class="usage-item">ETA: <span id="statsEta">0</span></div>
+      </div>
+    </details>
+
+    <div class="grid-2">
+      <div>
+        <label for="source">Source Language</label>
+        <select id="source" title="Language to translate from. Use 'Auto-detect' for convenience and mixed-language pages."></select>
         </div>
         <div>
           <label for="target">Target Language</label>

--- a/src/popup.js
+++ b/src/popup.js
@@ -32,6 +32,9 @@ const testBtn = document.getElementById('test') || document.createElement('butto
 const progressBar = document.getElementById('progress') || document.createElement('progress');
 const providerPreset = document.getElementById('providerPreset') || document.createElement('select');
 const clearPairBtn = document.getElementById('clearPair') || document.createElement('button');
+const statsReq = document.getElementById('statsRequests') || document.createElement('span');
+const statsTok = document.getElementById('statsTokens') || document.createElement('span');
+const statsEta = document.getElementById('statsEta') || document.createElement('span');
 
 // Collapsible sections
 const sectionIds = ['providerSection', 'detectionSection', 'rateSection', 'cacheSection'];
@@ -200,6 +203,12 @@ chrome.runtime.onMessage.addListener(msg => {
       setWorking(false);
     }
   }
+  if (msg.action === 'stats' && msg.stats) {
+    const { requests, tokens, eta } = msg.stats;
+    statsReq.textContent = requests;
+    statsTok.textContent = tokens;
+    statsEta.textContent = typeof eta === 'number' ? eta.toFixed(2) : '0';
+  }
 });
 
 chrome.runtime.sendMessage({ action: 'get-status' }, s => {
@@ -224,6 +233,14 @@ chrome.runtime.sendMessage({ action: 'get-status' }, s => {
     }
     setWorking(true);
   } else if (translateBtn) translateBtn.textContent = 'Translate Page';
+});
+
+chrome.runtime.sendMessage({ action: 'get-stats' }, res => {
+  if (res) {
+    statsReq.textContent = res.requests || 0;
+    statsTok.textContent = res.tokens || 0;
+    statsEta.textContent = typeof res.eta === 'number' ? res.eta.toFixed(2) : '0';
+  }
 });
 
 clearPairBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- aggregate requests, tokens and ETA in background and broadcast via runtime messages
- show live Stats card in popup displaying aggregated metrics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f9c7296dc83238d36234190f7ae50