### PR TITLE
feat: add frame styles to popup

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -106,7 +106,7 @@
     <!-- ===== MAIN VIEW ===== -->
     <div class="main-view">
       <div class="main-actions">
-        <button id="translate" class="primary-glow" title="Translate the current tab">Translate Page</button>
+        <button id="translate" class="primary-glow btn-frame" title="Translate the current tab">Translate Page</button>
         <div class="auto-translate-toggle">
           <label class="switch">
             <input type="checkbox" id="auto">
@@ -121,7 +121,7 @@
         <label title="Light theme"><input type="checkbox" id="lightMode"> Light</label>
       </div>
 
-      <details open id="usageDetails">
+      <details open id="usageDetails" class="panel-frame">
         <summary>Usage</summary>
         <div class="usage-section">
           <div class="usage-item">
@@ -139,7 +139,7 @@
       <div id="costSection"></div>
     </details>
 
-    <details id="statsDetails" open>
+    <details id="statsDetails" open class="panel-frame">
       <summary>Stats</summary>
       <div class="usage-section">
         <div class="usage-item">Requests: <span id="statsRequests">0</span></div>
@@ -159,7 +159,7 @@
         </div>
       </div>
 
-      <details>
+      <details class="panel-frame">
         <summary>Getting Started</summary>
         <ol>
           <li>Open Advanced Settings and choose a Provider preset, then paste your API key.</li>
@@ -176,7 +176,7 @@
         </ul>
       </details>
 
-      <details id="providerSection">
+      <details id="providerSection" class="panel-frame">
         <summary>Provider</summary>
         <div class="form-group" style="padding-top: 0.75rem">
           <label for="apiKey">API Key</label>
@@ -206,7 +206,7 @@
         </div>
       </details>
 
-      <details id="detectionSection">
+      <details id="detectionSection" class="panel-frame">
         <summary>Detection</summary>
         <div class="form-group" style="padding-top: 0.75rem">
           <label for="detector">Detector</label>
@@ -228,7 +228,7 @@
         </div>
       </details>
 
-      <details id="rateSection">
+      <details id="rateSection" class="panel-frame">
         <summary>Rate Limits</summary>
         <div class="form-group" style="padding-top: 0.75rem">
           <div class="grid-2">
@@ -251,7 +251,7 @@
         </div>
       </details>
 
-      <details id="cacheSection">
+      <details id="cacheSection" class="panel-frame">
       <summary>Cache &amp; Debug</summary>
         <div class="form-group" style="padding-top: 0.75rem">
           <label for="memCacheMax">Memory cache max</label>
@@ -266,7 +266,7 @@
         </div>
       </details>
 
-      <button id="test" class="secondary">Test Settings</button>
+      <button id="test" class="secondary btn-frame">Test Settings</button>
       <progress id="progress" value="0" max="1" style="width:100%;display:none"></progress>
       <div id="status"></div>
       <div id="version"></div>

--- a/src/styles/cyberpunk.css
+++ b/src/styles/cyberpunk.css
@@ -87,6 +87,18 @@
   background: var(--qwen-secondary-hover);
 }
 
+[data-qwen-theme="cyberpunk"] .btn-frame {
+  border-color: var(--qwen-neon-1);
+  box-shadow: 0 0 4px var(--qwen-neon-1), 0 2px 6px rgba(0, 0, 0, 0.5);
+}
+
+[data-qwen-theme="cyberpunk"] .panel-frame {
+  padding: 0.5rem;
+  border: 1px solid var(--qwen-neon-1);
+  border-radius: 8px;
+  box-shadow: 0 0 6px var(--qwen-neon-1), 0 2px 8px rgba(0, 0, 0, 0.6);
+}
+
 body.qwen-compact {
   --body-width: 320px;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary
- add `.btn-frame` and `.panel-frame` utilities with neon borders and drop-shadows
- apply new frame classes to popup buttons and section panels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f9eb9dcac8323a2316be91b2624e5