### PR TITLE
feat: add optional qwen-mt-plus fallback

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -302,7 +302,7 @@ async function selectProvider(p, providerOrder) {
 }
 
 async function handleTranslate(opts) {
-  const { endpoint, apiKey, model, text, source, target, debug, providerOrder, endpoints, failover, parallel } = opts;
+  const { endpoint, apiKey, model, secondaryModel, text, source, target, debug, providerOrder, endpoints, failover, parallel } = opts;
   const provider = await selectProvider(opts.provider || 'qwen', providerOrder);
   const epBase = (endpoints && endpoints[provider]) || endpoint;
   const ep = epBase.endsWith('/') ? epBase : `${epBase}/`;
@@ -321,6 +321,7 @@ async function handleTranslate(opts) {
       endpoint: ep,
       apiKey: storedKey,
       model,
+      secondaryModel,
       provider,
       text,
       source,

--- a/src/lib/messaging.js
+++ b/src/lib/messaging.js
@@ -4,7 +4,7 @@
   else root.qwenMessaging = mod;
 }(typeof self !== 'undefined' ? self : this, function (root) {
   const logger = (root.qwenLogger && root.qwenLogger.create) ? root.qwenLogger.create('messaging') : console;
-  function requestViaBackground({ endpoint, apiKey, model, text, source, target, debug, stream = false, signal, onData, provider, providerOrder, endpoints, failover, parallel }) {
+  function requestViaBackground({ endpoint, apiKey, model, secondaryModel, text, source, target, debug, stream = false, signal, onData, provider, providerOrder, endpoints, failover, parallel }) {
     if (!(root.chrome && root.chrome.runtime)) return Promise.reject(new Error('No chrome.runtime'));
     const ep = endpoint && /\/$/.test(endpoint) ? endpoint : (endpoint ? endpoint + '/' : endpoint);
     if (root.chrome.runtime.connect) {
@@ -39,14 +39,14 @@
         port.onDisconnect.addListener(() => {
           if (!settled) { settled = true; reject(new Error('Background disconnected')); }
         });
-        port.postMessage({ action: 'translate', requestId, opts: { endpoint: ep, apiKey, model, text, source, target, debug, stream, provider, providerOrder, endpoints, failover, parallel } });
+        port.postMessage({ action: 'translate', requestId, opts: { endpoint: ep, apiKey, model, secondaryModel, text, source, target, debug, stream, provider, providerOrder, endpoints, failover, parallel } });
       });
     }
     // Legacy sendMessage (non-streaming)
     return new Promise((resolve, reject) => {
       try {
         root.chrome.runtime.sendMessage(
-          { action: 'translate', opts: { endpoint: ep, apiKey, model, text, source, target, debug, provider, providerOrder, endpoints, failover, parallel } },
+          { action: 'translate', opts: { endpoint: ep, apiKey, model, secondaryModel, text, source, target, debug, provider, providerOrder, endpoints, failover, parallel } },
           res => {
             if (root.chrome.runtime.lastError) reject(new Error(root.chrome.runtime.lastError.message));
             else if (!res) reject(new Error('No response from background'));

--- a/src/providerConfig.js
+++ b/src/providerConfig.js
@@ -7,6 +7,8 @@ function applyProviderConfig(provider, doc = document) {
     'projectId',
     'location',
     'documentModel',
+    'secondaryModel',
+    'secondaryModelWarning',
   ];
   all.forEach(name => {
     const show = fields.includes(name);

--- a/src/providers/qwen.js
+++ b/src/providers/qwen.js
@@ -39,99 +39,113 @@ function fetchViaXHR(url, { method = 'GET', headers = {}, body, signal }, debug)
   });
 }
 
-async function translate({ endpoint, apiKey, model, text, source, target, signal, debug, onData, stream = true }) {
-  const url = `${withSlash(endpoint)}services/aigc/text-generation/generation`;
-  if (debug) {
-    console.log('QTDEBUG: sending translation request to', url);
-    console.log('QTDEBUG: request params', { model, source, target, text });
-  }
-  const body = {
-    model,
-    input: { messages: [{ role: 'user', content: text }] },
-    parameters: {
-      translation_options: { source_lang: source, target_lang: target },
-    },
-  };
-  if (debug) console.log('QTDEBUG: request body', body);
-  const key = (apiKey || '').trim();
-  const headers = { 'Content-Type': 'application/json' };
-  if (key) headers.Authorization = /^bearer\s/i.test(key) ? key : `Bearer ${key}`;
-  if (stream) headers['X-DashScope-SSE'] = 'enable';
-  let resp;
-  try {
-    resp = await fetchFn(url, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(body),
-      signal,
-    });
+async function translate({ endpoint, apiKey, model, secondaryModel, text, source, target, signal, debug, onData, stream = true }) {
+  async function attempt(m) {
+    const url = `${withSlash(endpoint)}services/aigc/text-generation/generation`;
     if (debug) {
-      console.log('QTDEBUG: response status', resp.status);
-      console.log('QTDEBUG: response headers', Object.fromEntries(resp.headers.entries()));
+      console.log('QTDEBUG: sending translation request to', url);
+      console.log('QTDEBUG: request params', { model: m, source, target, text });
     }
-  } catch (e) {
-    if (!stream && typeof XMLHttpRequest !== 'undefined') {
-      if (debug) console.log('QTDEBUG: fetch failed, falling back to XHR');
-      resp = await fetchViaXHR(url, { method: 'POST', headers, body: JSON.stringify(body), signal }, debug);
-    } else {
-      e.retryable = true;
-      throw e;
-    }
-  }
-  if (!resp.ok) {
-    const err = await resp.json().catch(() => ({ message: resp.statusText }));
-    const error = new Error(`HTTP ${resp.status}: ${err.message || 'Translation failed'}`);
-    if (debug) console.log('QTDEBUG: HTTP error response', error.message);
-    if (resp.status >= 500 || resp.status === 429) {
-      error.retryable = true;
-      const ra = resp.headers.get('retry-after');
-      if (ra) {
-        const ms = parseInt(ra, 10) * 1000;
-        if (ms > 0) error.retryAfter = ms;
+    const body = {
+      model: m,
+      input: { messages: [{ role: 'user', content: text }] },
+      parameters: {
+        translation_options: { source_lang: source, target_lang: target },
+      },
+    };
+    if (debug) console.log('QTDEBUG: request body', body);
+    const key = (apiKey || '').trim();
+    const headers = { 'Content-Type': 'application/json' };
+    if (key) headers.Authorization = /^bearer\s/i.test(key) ? key : `Bearer ${key}`;
+    if (stream) headers['X-DashScope-SSE'] = 'enable';
+    let resp;
+    try {
+      resp = await fetchFn(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+        signal,
+      });
+      if (debug) {
+        console.log('QTDEBUG: response status', resp.status);
+        console.log('QTDEBUG: response headers', Object.fromEntries(resp.headers.entries()));
       }
-      if (resp.status === 429 && !error.retryAfter) error.retryAfter = 60000;
-    }
-    throw error;
-  }
-  if (!stream || !resp.body || typeof resp.body.getReader !== 'function') {
-    if (debug) console.log('QTDEBUG: received non-streaming response');
-    const data = await resp.json();
-    const t = data.output?.text || data.output?.choices?.[0]?.message?.content;
-    if (!t) {
-      throw new Error('Invalid API response');
-    }
-    return { text: t };
-  }
-  if (debug) console.log('QTDEBUG: reading streaming response');
-  const reader = resp.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-  let result = '';
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split('\n');
-    buffer = lines.pop();
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed.startsWith('data:')) continue;
-      const data = trimmed.slice(5).trim();
-      if (debug) console.log('QTDEBUG: raw line', data);
-      if (data === '[DONE]') {
-        reader.cancel();
-        break;
+    } catch (e) {
+      if (!stream && typeof XMLHttpRequest !== 'undefined') {
+        if (debug) console.log('QTDEBUG: fetch failed, falling back to XHR');
+        resp = await fetchViaXHR(url, { method: 'POST', headers, body: JSON.stringify(body), signal }, debug);
+      } else {
+        e.retryable = true;
+        throw e;
       }
-      try {
-        const obj = JSON.parse(data);
-        const chunk = obj.output?.text || obj.output?.choices?.[0]?.message?.content || '';
-        result += chunk;
-        if (onData && chunk) onData(chunk);
-        if (debug && chunk) console.log('QTDEBUG: chunk received', chunk);
-      } catch {}
     }
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ message: resp.statusText }));
+      const error = new Error(`HTTP ${resp.status}: ${err.message || 'Translation failed'}`);
+      error.status = resp.status;
+      if (debug) console.log('QTDEBUG: HTTP error response', error.message);
+      if (resp.status >= 500 || resp.status === 429) {
+        error.retryable = true;
+        const ra = resp.headers.get('retry-after');
+        if (ra) {
+          const ms = parseInt(ra, 10) * 1000;
+          if (ms > 0) error.retryAfter = ms;
+        }
+        if (resp.status === 429 && !error.retryAfter) error.retryAfter = 60000;
+      }
+      throw error;
+    }
+    if (!stream || !resp.body || typeof resp.body.getReader !== 'function') {
+      if (debug) console.log('QTDEBUG: received non-streaming response');
+      const data = await resp.json();
+      const t = data.output?.text || data.output?.choices?.[0]?.message?.content;
+      if (!t) {
+        throw new Error('Invalid API response');
+      }
+      return { text: t };
+    }
+    if (debug) console.log('QTDEBUG: reading streaming response');
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let result = '';
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop();
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith('data:')) continue;
+        const data = trimmed.slice(5).trim();
+        if (debug) console.log('QTDEBUG: raw line', data);
+        if (data === '[DONE]') {
+          reader.cancel();
+          break;
+        }
+        try {
+          const obj = JSON.parse(data);
+          const chunk = obj.output?.text || obj.output?.choices?.[0]?.message?.content || '';
+          result += chunk;
+          if (onData && chunk) onData(chunk);
+          if (debug && chunk) console.log('QTDEBUG: chunk received', chunk);
+        } catch {}
+      }
+    }
+    return { text: result };
   }
-  return { text: result };
+
+  try {
+    return await attempt(model);
+  } catch (err) {
+    const limited = err && (err.status === 429 || /quota|limit/i.test(err.message || ''));
+    if (secondaryModel && limited) {
+      if (debug) console.log('QTDEBUG: falling back to', secondaryModel);
+      return await attempt(secondaryModel);
+    }
+    throw err;
+  }
 }
 
 async function getQuota({ endpoint, apiKey, model, debug }) {
@@ -166,7 +180,7 @@ const provider = {
   translate,
   getQuota,
   label: 'Qwen',
-  configFields: ['apiKey', 'apiEndpoint', 'model'],
+  configFields: ['apiKey', 'apiEndpoint', 'model', 'secondaryModel', 'secondaryModelWarning'],
   throttle: { requestLimit: 5, windowMs: 1000 },
 };
 

--- a/test/providerConfig.test.js
+++ b/test/providerConfig.test.js
@@ -8,6 +8,8 @@ test('hides unused fields based on provider config', () => {
     <label data-field="projectId"></label><input data-field="projectId">
     <label data-field="location"></label><input data-field="location">
     <label data-field="documentModel"></label><input data-field="documentModel">
+    <label data-field="secondaryModel"></label><input data-field="secondaryModel">
+    <div data-field="secondaryModelWarning"></div>
   `;
   const provider = { configFields: ['apiKey'] };
   applyProviderConfig(provider, document);
@@ -20,6 +22,8 @@ test('hides unused fields based on provider config', () => {
         '[data-field="projectId"]',
         '[data-field="location"]',
         '[data-field="documentModel"]',
+        '[data-field="secondaryModel"]',
+        '[data-field="secondaryModelWarning"]',
       ].join(', ')
     )
     .forEach(el => {

--- a/test/qwenFallback.test.js
+++ b/test/qwenFallback.test.js
@@ -1,0 +1,34 @@
+const provider = require('../src/providers/qwen');
+
+describe('qwen provider fallback', () => {
+  beforeEach(() => {
+    fetch.resetMocks();
+  });
+
+  test('falls back to secondary model on 429', async () => {
+    fetch
+      .mockResponseOnce(JSON.stringify({ message: 'limit' }), { status: 429 })
+      .mockResponseOnce(
+        JSON.stringify({ output: { text: 'hi' } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+
+    const res = await provider.translate({
+      endpoint: 'https://api.example.com',
+      apiKey: 'k',
+      model: 'primary',
+      secondaryModel: 'fallback',
+      text: 'hello',
+      source: 'en',
+      target: 'zh',
+      stream: false,
+    });
+
+    expect(res.text).toBe('hi');
+    expect(fetch.mock.calls.length).toBe(2);
+    const firstBody = JSON.parse(fetch.mock.calls[0][1].body);
+    const secondBody = JSON.parse(fetch.mock.calls[1][1].body);
+    expect(firstBody.model).toBe('primary');
+    expect(secondBody.model).toBe('fallback');
+  });
+});


### PR DESCRIPTION
## Summary
- expose secondary model toggle and warning in provider config
- allow Qwen provider to fall back to qwen-mt-plus on 429 or limit errors
- propagate secondary model through translator and messaging pipeline

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fa4036ad083239ea723b7af2790ea