### PR TITLE
feat: use slider for detection sensitivity

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -80,6 +80,8 @@
     .bar { height: 6px; background: var(--bar-bg); border-radius: 3px; overflow: hidden; margin-top: 2px; }
     .bar > div { height: 100%; width: 0%; transition: width 0.2s ease-in-out, background-color 0.2s ease-in-out; }
     .form-group { display: flex; flex-direction: column; gap: 0.5rem; }
+    .slider-group { display: flex; align-items: center; gap: 0.5rem; }
+    .slider-group span { font-size: 0.75rem; }
     label { font-size: 0.875rem; }
     .help { font-size: 0.75rem; opacity: 0.8; }
     .view-options { display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; }
@@ -236,9 +238,13 @@
           <small class="help">Required only when using Google detector.</small>
 
           <label for="sensitivity">Detection sensitivity</label>
-          <input type="number" id="sensitivity" min="0" max="1" step="0.1"
-                 title="Minimum confidence (0-1) required for detection to apply.">
-          <small class="help">Higher values need stronger signal. 0.2–0.6 typical.</small>
+          <div class="slider-group">
+            <span>Low</span>
+            <input type="range" id="sensitivity" min="0" max="1" step="0.1"
+                   title="Minimum confidence required from language detector.">
+            <span>High</span>
+          </div>
+          <small class="help">Minimum confidence required from language detector.</small>
         </div>
       </details>
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -88,7 +88,7 @@ function saveConfig() {
       sourceLanguage: sourceSelect.value,
       targetLanguage: targetSelect.value,
       detector: detectorSelect ? detectorSelect.value : 'local',
-      sensitivity: parseFloat(sensitivityInput.value) || 0,
+      sensitivity: sensitivityInput.valueAsNumber || 0,
       requestLimit: parseInt(reqLimitInput.value, 10) || 60,
       tokenLimit: parseInt(tokenLimitInput.value, 10) || 100000,
       tokenBudget: parseInt(tokenBudgetInput.value, 10) || 0,


### PR DESCRIPTION
## Summary
- replace numeric detection sensitivity field with 0–1 slider labeled Low to High
- read slider value as float when saving config

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fa5f9e26c832394ccf3eceb0c15bd