### PR TITLE
feat: parallelize batch requests

### DIFF
--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -74,6 +74,22 @@
       info(...a)  { if (lvl >= 2) { const red = redact(a); base.info(...format(ns, red)); emit('info', ns, red); } },
       warn(...a)  { if (lvl >= 1) { const red = redact(a); base.warn(...format(ns, red)); emit('warn', ns, red); } },
       error(...a) { const red = redact(a); base.error(...format(ns, red)); emit('error', ns, red); },
+      async time(fn) {
+        const start = Date.now();
+        try {
+          const result = await fn();
+          const ms = Date.now() - start;
+          const red = redact([{ latencyMs: ms }]);
+          emit('debug', ns, red);
+          return { result, ms };
+        } catch (err) {
+          const ms = Date.now() - start;
+          const red = redact([{ latencyMs: ms, error: err && err.message }]);
+          emit('debug', ns, red);
+          if (err && typeof err === 'object') err.latencyMs = ms;
+          throw err;
+        }
+      },
     };
   }
   return { create, parseLevel, addCollector };

--- a/test/translator.parallel.test.js
+++ b/test/translator.parallel.test.js
@@ -29,4 +29,39 @@ describe('translator parallel mode', () => {
     expect(a.translate).toHaveBeenCalledTimes(2);
     expect(b.translate).toHaveBeenCalledTimes(2);
   });
+
+  test('respects requestLimit when parallel', async () => {
+    const Providers = require('../src/lib/providers.js');
+    Providers.reset();
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const a = {
+      translate: jest.fn(async ({ text }) => {
+        inFlight++;
+        if (inFlight > maxInFlight) maxInFlight = inFlight;
+        await new Promise(r => setTimeout(r, 5));
+        inFlight--;
+        return { text: `A:${text}` };
+      })
+    };
+    Providers.register('a', a);
+    Providers.init();
+    const tr = require('../src/translator.js');
+    tr._setGetUsage(() => ({ requestLimit: 2 }));
+    const res = await tr.qwenTranslateBatch({
+      texts: ['one', 'two', 'three', 'four'],
+      source: 'en',
+      target: 'fr',
+      tokenBudget: 100,
+      maxBatchSize: 1,
+      providerOrder: ['a'],
+      parallel: true,
+      failover: false,
+      noProxy: true,
+    });
+    expect(a.translate).toHaveBeenCalledTimes(4);
+    expect(maxInFlight).toBeLessThanOrEqual(2);
+    expect(res.stats.avgRequestMs).toBeGreaterThan(0);
+    expect(res.stats.requestsPerSecond).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Summary
- dispatch batched translations in parallel up to request limit
- expose latency tracking and average request speed
- cover requestLimit behavior with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fa76410208323b03a32e76255a1fc