### PR TITLE
feat: add translation confidence scoring and feedback UI

### DIFF
--- a/src/lib/feedback.js
+++ b/src/lib/feedback.js
@@ -1,0 +1,41 @@
+(function (root, factory) {
+  const mod = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
+  else root.qwenFeedback = mod;
+}(typeof self !== 'undefined' ? self : this, function (root) {
+  const hasIDB = typeof indexedDB !== 'undefined';
+  const DB_NAME = 'qwen-feedback';
+  const STORE_NAME = 'fb';
+  let dbPromise;
+
+  function getDB() {
+    if (!hasIDB) return null;
+    if (!dbPromise) {
+      dbPromise = new Promise(resolve => {
+        try {
+          const req = indexedDB.open(DB_NAME, 1);
+          req.onupgradeneeded = () => {
+            req.result.createObjectStore(STORE_NAME, { autoIncrement: true });
+          };
+          req.onsuccess = () => resolve(req.result);
+          req.onerror = () => resolve(null);
+        } catch {
+          resolve(null);
+        }
+      });
+    }
+    return dbPromise;
+  }
+
+  async function save(record) {
+    const db = await getDB();
+    if (!db) return;
+    try {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      tx.objectStore(STORE_NAME).add({ ...record, ts: Date.now() });
+      await new Promise(res => { tx.oncomplete = res; tx.onerror = res; });
+    } catch {}
+  }
+
+  return { save };
+}));


### PR DESCRIPTION
## Summary
- score translations in background.js using a simple length-ratio heuristic
- allow users to mark translations as Good or Needs Fix with feedback stored in IndexedDB

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb26f364083239a99c8ee4e118bf1