### PR TITLE
feat: expose per-provider config

### DIFF
--- a/src/popup/providers.html
+++ b/src/popup/providers.html
@@ -71,7 +71,7 @@
         <summary>Advanced</summary>
         <div class="form-group">
           <label>Models<input type="text" data-field="models" placeholder="comma separated"></label>
-          <label>Chars/month<input type="number" data-field="charLimit" min="0"></label>
+          <div class="extra-limits"></div>
           <label>Strategy
             <select data-field="strategy">
               <option value="balanced">Balanced</option>

--- a/src/popup/providers.html
+++ b/src/popup/providers.html
@@ -22,6 +22,26 @@
       cursor: move;
       background: rgba(0,0,0,0.2);
     }
+    .provider-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      align-items: center;
+    }
+    .provider-row .provider-name {
+      min-width: 6rem;
+    }
+    .provider-row input {
+      flex: 1;
+      min-width: 6rem;
+    }
+    .model-warning {
+      color: #ffae00;
+      font-size: 0.8rem;
+    }
+    .invalid {
+      border-color: #ff4d4f;
+    }
     .flags { margin-top: 1rem; display: flex; gap: 1rem; align-items: center; }
     .form-group { display: flex; flex-direction: column; gap: 0.5rem; margin-top: 0.5rem; }
     .form-group input, .form-group select { width: 100%; }
@@ -39,15 +59,19 @@
 
   <template id="providerTemplate">
     <li draggable="true">
+      <div class="provider-row">
+        <span class="provider-name"></span>
+        <input type="text" data-field="apiKey" placeholder="API Key">
+        <input type="text" data-field="apiEndpoint" placeholder="Endpoint">
+        <input type="text" data-field="model" placeholder="Model">
+        <input type="number" data-field="requestLimit" placeholder="Req/min" min="0">
+        <input type="number" data-field="tokenLimit" placeholder="Tok/min" min="0">
+      </div>
       <details>
-        <summary class="provider-name"></summary>
+        <summary>Advanced</summary>
         <div class="form-group">
-          <label>API Key<input type="text" data-field="apiKey"></label>
-          <label>Endpoint<input type="text" data-field="apiEndpoint"></label>
           <label>Models<input type="text" data-field="models" placeholder="comma separated"></label>
-          <label>Requests/min<input type="number" data-field="requestLimit"></label>
-          <label>Tokens/min<input type="number" data-field="tokenLimit"></label>
-          <label>Chars/month<input type="number" data-field="charLimit"></label>
+          <label>Chars/month<input type="number" data-field="charLimit" min="0"></label>
           <label>Strategy
             <select data-field="strategy">
               <option value="balanced">Balanced</option>
@@ -56,6 +80,7 @@
               <option value="quality">Optimize quality</option>
             </select>
           </label>
+          <div class="model-warning" style="display:none"></div>
         </div>
       </details>
     </li>

--- a/src/popup/providers.js
+++ b/src/popup/providers.js
@@ -9,7 +9,42 @@
     ? cfg.providerOrder.slice()
     : Object.keys(cfg.providers || {});
   const providers = cfg.providers || {};
-  const fields = ['apiKey','apiEndpoint','models','requestLimit','tokenLimit','charLimit','strategy'];
+  const fields = ['apiKey','apiEndpoint','model','models','requestLimit','tokenLimit','charLimit','strategy'];
+  const numericFields = ['requestLimit','tokenLimit','charLimit'];
+
+  function validateNumber(input) {
+    const v = input.value.trim();
+    if (!v) {
+      input.classList.remove('invalid');
+      return true;
+    }
+    const n = Number(v);
+    const ok = Number.isFinite(n) && n >= 0;
+    input.classList.toggle('invalid', !ok);
+    return ok;
+  }
+
+  function updateCostWarning(li) {
+    const model = li.querySelector('[data-field="model"]')?.value.trim();
+    const modelsInput = li.querySelector('[data-field="models"]');
+    const warn = li.querySelector('.model-warning');
+    if (!warn) return;
+    const models = modelsInput?.value
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean) || [];
+    const set = new Set(models);
+    if (model) set.add(model);
+    const hasPlus = set.has('qwen-mt-plus');
+    const hasTurbo = set.has('qwen-mt-turbo');
+    if (hasPlus && hasTurbo) {
+      warn.textContent = 'Models have different costs';
+      warn.style.display = '';
+    } else {
+      warn.textContent = '';
+      warn.style.display = 'none';
+    }
+  }
 
   function createItem(id) {
     const data = providers[id] || {};
@@ -23,6 +58,15 @@
       if (Array.isArray(v)) v = v.join(', ');
       if (v != null) input.value = v;
     });
+    ['model','models'].forEach(f => {
+      const input = li.querySelector(`[data-field="${f}"]`);
+      if (input) input.addEventListener('input', () => updateCostWarning(li));
+    });
+    numericFields.forEach(f => {
+      const input = li.querySelector(`[data-field="${f}"]`);
+      if (input) input.addEventListener('input', () => validateNumber(input));
+    });
+    updateCostWarning(li);
     li.addEventListener('dragstart', e => {
       e.dataTransfer.setData('text/plain', id);
       e.dataTransfer.effectAllowed = 'move';
@@ -54,6 +98,7 @@
   document.getElementById('save').addEventListener('click', async () => {
     const newOrder = Array.from(list.children).map(li => li.dataset.id);
     const newProviders = {};
+    let valid = true;
     Array.from(list.children).forEach(li => {
       const id = li.dataset.id;
       const data = {};
@@ -65,7 +110,8 @@
           let models = v.split(',').map(s => s.trim()).filter(Boolean);
           if (models.includes('qwen-mt-turbo') && !models.includes('qwen-mt-plus')) models.push('qwen-mt-plus');
           data.models = models;
-        } else if (['requestLimit','tokenLimit','charLimit'].includes(f)) {
+        } else if (numericFields.includes(f)) {
+          if (!validateNumber(input)) valid = false;
           data[f] = parseInt(v, 10) || 0;
         } else {
           data[f] = v;
@@ -81,6 +127,10 @@
       }
       newProviders[id] = data;
     });
+    if (!valid) {
+      status.textContent = 'Please fix invalid numbers';
+      return;
+    }
     cfg.providerOrder = newOrder;
     cfg.providers = newProviders;
     cfg.failover = failoverBox.checked;


### PR DESCRIPTION
## Summary
- add inline inputs for API key, endpoint, model, and rate limits per provider
- validate numeric provider fields and warn when model costs differ

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fbb978278832387e167ee3ff9e1e0