### PR TITLE
feat: add macOS translation provider

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -222,6 +222,7 @@
             <option value="openai">OpenAI</option>
             <option value="openrouter">OpenRouter</option>
             <option value="deepl">DeepL</option>
+            <option value="macos">macOS</option>
           </select>
           <small class="help">Auto-fills endpoint and model; still paste your own key.</small>
         </div>
@@ -317,6 +318,7 @@
   <script src="providers/openrouter.js"></script>
   <script src="providers/deepl.js"></script>
   <script src="providers/dashscope.js"></script>
+  <script src="providers/macos.js"></script>
   <script src="lib/messaging.js"></script>
   <script src="lib/glossary.js"></script>
   <script src="translator.js"></script>

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -7,6 +7,7 @@ function initProviders() {
     deepl: require('./deepl').basic,
     'deepl-free': require('./deepl').free,
     'deepl-pro': require('./deepl').pro,
+    macos: { ...require('./macos'), label: 'macOS' },
     openrouter: { ...require('./openrouter'), label: 'OpenRouter' },
   });
 }

--- a/src/providers/macos.js
+++ b/src/providers/macos.js
@@ -1,0 +1,19 @@
+(function (root, factory) {
+  const mod = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
+  else root.qwenProviderMacOS = mod;
+}(typeof self !== 'undefined' ? self : this, function (root) {
+  async function translate({ text, source, target }) {
+    const handler = root && root.webkit && root.webkit.messageHandlers && root.webkit.messageHandlers.translate;
+    if (!handler || typeof handler.postMessage !== 'function') {
+      throw new Error('macOS translate handler not available');
+    }
+    return handler.postMessage({ text, source, target });
+  }
+  const provider = { translate, configFields: [] };
+  try {
+    const reg = root.qwenProviders || (typeof require !== 'undefined' ? require('../lib/providers') : null);
+    if (reg && reg.register && !reg.get('macos')) reg.register('macos', { ...provider, label: 'macOS' });
+  } catch {}
+  return provider;
+}));


### PR DESCRIPTION
## Summary
- add macOS translation provider that forwards requests to `window.webkit`
- register macOS provider and expose it as a preset in the popup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fbe5a87c48323b8832e59cc0752ed