### PR TITLE
feat: add Ollama provider

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -223,6 +223,7 @@
             <option value="openrouter">OpenRouter</option>
             <option value="deepl">DeepL</option>
             <option value="macos">macOS</option>
+            <option value="ollama">Ollama</option>
           </select>
           <small class="help">Auto-fills endpoint and model; still paste your own key.</small>
         </div>
@@ -319,6 +320,7 @@
   <script src="providers/deepl.js"></script>
   <script src="providers/dashscope.js"></script>
   <script src="providers/macos.js"></script>
+  <script src="providers/ollama.js"></script>
   <script src="lib/messaging.js"></script>
   <script src="lib/glossary.js"></script>
   <script src="translator.js"></script>

--- a/src/popup.js
+++ b/src/popup.js
@@ -419,7 +419,8 @@ window.qwenLoadConfig().then(cfg => {
         dashscope: { endpoint: 'https://dashscope-intl.aliyuncs.com/api/v1', model: 'qwen-mt-turbo' },
         openai:    { endpoint: 'https://api.openai.com/v1',                   model: 'gpt-4o-mini' },
         openrouter:{ endpoint: 'https://openrouter.ai/api/v1',               model: 'gpt-4o-mini' },
-        deepl:     { endpoint: 'https://api.deepl.com/v2',                    model: 'deepl' }
+        deepl:     { endpoint: 'https://api.deepl.com/v2',                    model: 'deepl' },
+        ollama:    { endpoint: 'http://localhost:11434',                     model: 'qwen2:latest' }
       };
       const p = presets[v];
       if (p) {
@@ -440,6 +441,7 @@ window.qwenLoadConfig().then(cfg => {
       else if (v.includes('openrouter')) inferred = 'openrouter';
       else if (v.includes('deepl')) inferred = 'deepl';
       else if (v.includes('dashscope')) inferred = 'dashscope';
+      else if (v.includes('11434') || v.includes('ollama')) inferred = 'ollama';
       if (inferred && providerPreset) {
         providerPreset.value = inferred;
         providerPreset.dispatchEvent(new Event('change'));

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -9,6 +9,7 @@ function initProviders() {
     'deepl-pro': require('./deepl').pro,
     macos: { ...require('./macos'), label: 'macOS' },
     openrouter: { ...require('./openrouter'), label: 'OpenRouter' },
+    ollama: { ...require('./ollama'), label: 'Ollama' },
   });
 }
 

--- a/src/providers/ollama.js
+++ b/src/providers/ollama.js
@@ -1,0 +1,89 @@
+(function (root, factory) {
+  const mod = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
+  else root.qwenProviderOllama = mod;
+}(typeof self !== 'undefined' ? self : this, function (root) {
+  const logger = (root.qwenLogger && root.qwenLogger.create) ? root.qwenLogger.create('provider:ollama') : console;
+  const fetchFn = (typeof fetch !== 'undefined') ? fetch : (root.fetch || null);
+  function withSlash(u) { return /\/$/.test(u) ? u : (u + '/'); }
+
+  async function translate({ endpoint, model, text, source, target, signal, debug, onData, stream = true }) {
+    if (!fetchFn) throw new Error('fetch not available');
+    const base = withSlash(endpoint || 'http://localhost:11434');
+    const url = base + 'api/generate';
+    const prompt = `Translate the following text from ${source} to ${target}. Output only the translation.\n\n${text}`;
+    const body = { model, prompt, stream: !!stream };
+    const headers = { 'Content-Type': 'application/json' };
+
+    if (debug) {
+      logger.debug('sending translation request to', url);
+      logger.debug('request params', { model, source, target });
+    }
+
+    let resp;
+    try {
+      resp = await fetchFn(url, { method: 'POST', headers, body: JSON.stringify(body), signal });
+    } catch (e) {
+      e.retryable = true;
+      throw e;
+    }
+
+    if (!resp.ok) {
+      let msg = resp.statusText;
+      try { const err = await resp.json(); msg = err.error || err.message || msg; } catch {}
+      const error = new Error(`HTTP ${resp.status}: ${msg}`);
+      error.status = resp.status;
+      if (resp.status >= 500 || resp.status === 429) {
+        error.retryable = true;
+        const ra = resp.headers.get('retry-after');
+        if (ra) {
+          const ms = parseInt(ra, 10) * 1000;
+          if (ms > 0) error.retryAfter = ms;
+        }
+        if (resp.status === 429 && !error.retryAfter) error.retryAfter = 60000;
+      }
+      throw error;
+    }
+
+    if (!stream || !resp.body || typeof resp.body.getReader !== 'function') {
+      const data = await resp.json();
+      const out = data.response || '';
+      if (!out) throw new Error('Invalid API response');
+      return { text: out };
+    }
+
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let result = '';
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop();
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const obj = JSON.parse(trimmed);
+          const chunk = obj.response || '';
+          if (chunk) {
+            result += chunk;
+            if (onData) onData(chunk);
+            if (debug) logger.debug('chunk received', chunk);
+          }
+          if (obj.done) { try { reader.cancel(); } catch {} break; }
+        } catch {}
+      }
+    }
+    return { text: result };
+  }
+
+  const provider = { translate, throttle: { requestLimit: 60, windowMs: 60000 } };
+  try {
+    const reg = root.qwenProviders || (typeof require !== 'undefined' ? require('../lib/providers') : null);
+    if (reg && reg.register && !reg.get('ollama')) reg.register('ollama', provider);
+  } catch {}
+  return provider;
+}));


### PR DESCRIPTION
## Summary
- add Ollama provider that streams translations from a local Ollama server
- expose provider option and preset in popup
- register Ollama with provider registry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fbfcbd8a48323b116fd3996d50c0e