### PR TITLE
Add usage link and latency stats to popup

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -239,7 +239,10 @@ function getAggregatedStats() {
   const { totalRequests, totalTokens, tokenLimit, tokens } = self.qwenThrottle.getUsage();
   const remaining = Math.max(0, tokenLimit - tokens);
   const eta = tokenLimit ? remaining / tokenLimit : 0;
-  return { requests: totalRequests, tokens: totalTokens, eta };
+  const avgLatency = usageLog.length
+    ? usageLog.reduce((sum, e) => sum + (e.latency || 0), 0) / usageLog.length
+    : 0;
+  return { requests: totalRequests, tokens: totalTokens, eta, avgLatency };
 }
 
 function broadcastStats() {

--- a/src/popup.html
+++ b/src/popup.html
@@ -163,11 +163,12 @@
     <details id="statsDetails" open class="panel-frame">
       <summary>Stats</summary>
       <div class="usage-section">
-        <div class="usage-item">Requests: <span id="statsRequests">0</span></div>
-        <div class="usage-item">Tokens: <span id="statsTokens">0</span></div>
-        <div class="usage-item">ETA: <span id="statsEta">0</span></div>
+        <div class="usage-item">Total Requests: <span id="statsRequests">0</span></div>
+        <div class="usage-item">Total Tokens: <span id="statsTokens">0</span></div>
+        <div class="usage-item">Avg Latency: <span id="statsLatency">0</span> ms</div>
       </div>
     </details>
+    <a href="qa/usage.html" target="_blank" rel="noopener">Usage</a>
 
     <div class="grid-2">
       <div>

--- a/src/popup.js
+++ b/src/popup.js
@@ -35,7 +35,7 @@ const providerPreset = document.getElementById('providerPreset') || document.cre
 const clearPairBtn = document.getElementById('clearPair') || document.createElement('button');
 const statsReq = document.getElementById('statsRequests') || document.createElement('span');
 const statsTok = document.getElementById('statsTokens') || document.createElement('span');
-const statsEta = document.getElementById('statsEta') || document.createElement('span');
+const statsLatency = document.getElementById('statsLatency') || document.createElement('span');
 const calibrationStatus = document.getElementById('calibrationStatus') || document.createElement('div');
 const resetCalibrationBtn = document.getElementById('resetCalibration') || document.createElement('button');
 const importGlossaryInput = document.getElementById('importGlossary') || document.createElement('input');
@@ -265,10 +265,10 @@ chrome.runtime.onMessage.addListener(msg => {
     }
   }
   if (msg.action === 'stats' && msg.stats) {
-    const { requests, tokens, eta } = msg.stats;
+    const { requests, tokens, avgLatency } = msg.stats;
     statsReq.textContent = requests;
     statsTok.textContent = tokens;
-    statsEta.textContent = typeof eta === 'number' ? eta.toFixed(2) : '0';
+    statsLatency.textContent = typeof avgLatency === 'number' ? avgLatency.toFixed(0) : '0';
   }
 });
 
@@ -304,7 +304,7 @@ chrome.runtime.sendMessage({ action: 'get-stats' }, res => {
   if (res) {
     statsReq.textContent = res.requests || 0;
     statsTok.textContent = res.tokens || 0;
-    statsEta.textContent = typeof res.eta === 'number' ? res.eta.toFixed(2) : '0';
+    statsLatency.textContent = typeof res.avgLatency === 'number' ? res.avgLatency.toFixed(0) : '0';
   }
 });
 


### PR DESCRIPTION
## Summary
- expose average latency in stats broadcast and popup
- show total requests and tokens with average latency in popup stats
- add Usage link to open qa/usage.html

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fc130955483238459c28fd0bb6078