### PR TITLE
Fix Qwen rate-limit bar and expose quota endpoint

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -477,6 +477,22 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     });
     return true;
   }
+  if (msg.action === 'quota') {
+    const model = msg.model;
+    const cfg = self.qwenConfig || {};
+    const prov = self.qwenProviders && self.qwenProviders.getProvider && self.qwenProviders.getProvider('qwen');
+    if (prov && prov.getQuota) {
+      prov.getQuota({
+        endpoint: (cfg.providers && cfg.providers.qwen && cfg.providers.qwen.apiEndpoint) || cfg.apiEndpoint,
+        apiKey: (cfg.providers && cfg.providers.qwen && cfg.providers.qwen.apiKey) || cfg.apiKey,
+        model: model || cfg.model,
+        debug: cfg.debug,
+      }).then(sendResponse).catch(err => sendResponse({ error: err.message }));
+      return true;
+    }
+    sendResponse({ error: 'provider unavailable' });
+    return true;
+  }
   if (msg.action === 'detect') {
     const opts = msg.opts || {};
     (async () => {

--- a/src/popup.js
+++ b/src/popup.js
@@ -145,7 +145,7 @@ function saveConfig() {
       detector: detectorSelect ? detectorSelect.value : 'local',
       sensitivity: sensitivityInput.valueAsNumber || 0,
       requestLimit: parseInt(reqLimitInput.value, 10) || 60,
-      tokenLimit: parseInt(tokenLimitInput.value, 10) || 100000,
+      tokenLimit: parseInt(tokenLimitInput.value, 10) || (window.qwenDefaultConfig && window.qwenDefaultConfig.tokenLimit) || 0,
       tokenBudget: parseInt(tokenBudgetInput.value, 10) || 0,
       memCacheMax: parseInt(memCacheMaxInput.value, 10) || 0,
       autoTranslate: autoCheckbox.checked,
@@ -513,10 +513,12 @@ function refreshUsage() {
     const cfg = window.qwenConfig || {};
     const reqTotal = cfg.requestLimit || 0;
     const tokTotal = cfg.tokenLimit || 0;
-    setBar(reqBar, reqTotal ? res.totalRequests / reqTotal : 0);
-    setBar(tokenBar, tokTotal ? res.totalTokens / tokTotal : 0);
-    reqCount.textContent = reqTotal ? `${res.totalRequests}/${reqTotal}` : `${res.totalRequests}`;
-    tokenCount.textContent = tokTotal ? `${res.totalTokens}/${tokTotal}` : `${res.totalTokens}`;
+    const reqUsed = res.requests != null ? res.requests : res.totalRequests;
+    const tokUsed = res.tokens != null ? res.tokens : res.totalTokens;
+    setBar(reqBar, reqTotal ? reqUsed / reqTotal : 0);
+    setBar(tokenBar, tokTotal ? tokUsed / tokTotal : 0);
+    reqCount.textContent = reqTotal ? `${reqUsed}/${reqTotal}` : `${reqUsed}`;
+    tokenCount.textContent = tokTotal ? `${tokUsed}/${tokTotal}` : `${tokUsed}`;
     reqBar.title = `Requests: ${reqCount.textContent}`;
     tokenBar.title = `Tokens: ${tokenCount.textContent}`;
     renderProviderUsage(cfg, res);


### PR DESCRIPTION
## Summary
- derive token limit from default config instead of 100k magic number
- show per-minute request/token usage so progress bars move
- expose background "quota" action for fetching live model quotas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f940241908323901c3269d14814dd