### PR TITLE
fix: allow popup background to scroll with content

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -23,7 +23,8 @@
 
     html {
       height: 100%;
-      background: var(--bg-color) url('styles/popup-bg.svg') center/cover fixed no-repeat;
+      background: var(--bg-color) url('styles/popup-bg.svg') center/cover no-repeat;
+      background-attachment: local;
     }
 
     body {


### PR DESCRIPTION
## Summary
- allow popup background to scroll by using `background-attachment: local`
- keep popup body height and overflow so background grows with expanded sections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fd5d0fca08323a0903143af75ad95