### PR TITLE
Add supporter banner to popup

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -331,5 +331,6 @@
   <script src="languages.js"></script>
   <script src="usageColor.js"></script>
   <script src="popup.js"></script>
+  <script src="popup/support.js"></script>
 </body>
 </html>

--- a/src/popup/support.js
+++ b/src/popup/support.js
@@ -1,0 +1,37 @@
+(async () => {
+  if (typeof chrome === 'undefined' || !chrome.storage || !chrome.storage.sync) return;
+  const { supporter } = await new Promise(resolve => chrome.storage.sync.get(['supporter'], resolve));
+  const banner = document.createElement('div');
+  banner.id = 'supportBanner';
+  banner.style.cssText = 'font-size:0.75rem;background:var(--secondary-bg);border:1px solid var(--input-border);padding:4px;border-radius:4px;display:flex;gap:0.5rem;align-items:center;justify-content:center;margin-bottom:0.5rem;';
+  const container = document.body;
+  if (supporter) {
+    banner.textContent = 'You rock!';
+    container.prepend(banner);
+    return;
+  }
+  const msg = document.createElement('span');
+  msg.textContent = 'Support development:';
+  banner.appendChild(msg);
+  const donations = [
+    { label: 'Coffee €5', url: 'https://www.paypal.com/paypalme/yourname/5' },
+    { label: 'Beer €7', url: 'https://www.paypal.com/paypalme/yourname/7' },
+    { label: 'Dinner €20', url: 'https://www.paypal.com/paypalme/yourname/20' },
+  ];
+  donations.forEach(opt => {
+    const a = document.createElement('a');
+    a.textContent = opt.label;
+    a.href = opt.url;
+    a.target = '_blank';
+    a.rel = 'noopener';
+    a.style.color = 'var(--primary-color)';
+    a.addEventListener('click', async e => {
+      e.preventDefault();
+      if (chrome?.tabs?.create) chrome.tabs.create({ url: opt.url });
+      await chrome.storage.sync.set({ supporter: true });
+      banner.textContent = 'You rock!';
+    });
+    banner.appendChild(a);
+  });
+  container.prepend(banner);
+})();


### PR DESCRIPTION
## Summary
- add support.js to display donation banner with PayPal links and store supporter flag
- include support.js in popup.html

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fd6a7ac1c8323a9c1c154c92d33be