### PR TITLE
Add provider character usage bars with default limits

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -38,6 +38,9 @@ function migrate(cfg = {}) {
   if (!out.providers || typeof out.providers !== 'object') out.providers = {};
   const provider = out.provider || 'qwen';
   if (!out.providers[provider]) out.providers[provider] = {};
+  Object.entries(out.providers).forEach(([id, p]) => {
+    if (p.charLimit == null) p.charLimit = /^google$|^deepl/.test(id) ? 500000 : out.charLimit || 0;
+  });
   if (out.apiKey && !out.providers[provider].apiKey) out.providers[provider].apiKey = out.apiKey;
   if (out.apiEndpoint && !out.providers[provider].apiEndpoint) out.providers[provider].apiEndpoint = out.apiEndpoint;
   if (out.model && !out.providers[provider].model) out.providers[provider].model = out.model;
@@ -46,7 +49,6 @@ function migrate(cfg = {}) {
   if (!p.tokenLimit) p.tokenLimit = out.tokenLimit;
   if (!p.costPerToken) p.costPerToken = 0;
   if (!p.weight) p.weight = 0;
-  if (!p.charLimit) p.charLimit = out.charLimit || 0;
   if (!p.strategy) p.strategy = out.strategy || 'balanced';
   if (Array.isArray(cfg.models)) p.models = cfg.models.slice();
   else if (!p.models) p.models = p.model ? [p.model] : [];

--- a/src/popup.js
+++ b/src/popup.js
@@ -487,18 +487,22 @@ function renderProviderUsage(cfg, usage) {
   if (!providerUsage) return;
   providerUsage.innerHTML = '';
   const provs = cfg.providers || {};
+  const stats = (usage && usage.providers) || {};
   Object.entries(provs).forEach(([id, p]) => {
-    const models = p.models || (p.model ? [p.model] : []);
-    const limit = p.requestLimit || cfg.requestLimit || 0;
-    models.forEach(m => {
-      const used = usage.models && usage.models[m] ? usage.models[m].requests || 0 : 0;
-      const total = limit || 0;
-      const item = document.createElement('div');
-      item.className = 'usage-item';
-      const ratio = total ? Math.min(1, used / total) : 0;
-      item.innerHTML = `<span>${m}: ${used}${total ? '/' + total : ''}</span><div class="bar"><div style="width:${ratio * 100}%"></div></div>`;
-      providerUsage.appendChild(item);
-    });
+    const limit = p.charLimit || cfg.charLimit || 0;
+    const used = stats[id] ? stats[id].chars || 0 : 0;
+    const item = document.createElement('div');
+    item.className = 'usage-item';
+    const bar = document.createElement('div');
+    bar.className = 'bar';
+    const fill = document.createElement('div');
+    bar.appendChild(fill);
+    setBar(fill, limit ? used / limit : 0);
+    const label = document.createElement('span');
+    label.textContent = `${id}: ${used}${limit ? '/' + limit : ''}`;
+    item.appendChild(label);
+    item.appendChild(bar);
+    providerUsage.appendChild(item);
   });
 }
 


### PR DESCRIPTION
## Summary
- default Google and DeepL providers to a 500k monthly character limit
- show per-provider character usage bar in popup with warning color past 80%

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fd9a0355c832394f14c36cbd92d19