### PR TITLE
feat: add usage sparklines to stats

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -168,6 +168,8 @@
         <div class="usage-item">Total Requests: <span id="statsRequests">0</span></div>
         <div class="usage-item">Total Tokens: <span id="statsTokens">0</span></div>
         <div class="usage-item">Avg Latency: <span id="statsLatency">0</span> ms</div>
+        <div class="usage-item" style="grid-column: span 2;"><canvas id="reqSpark" height="30" style="width:100%;"></canvas></div>
+        <div class="usage-item" style="grid-column: span 2;"><canvas id="tokSpark" height="30" style="width:100%;"></canvas></div>
       </div>
     </details>
     <a href="qa/usage.html" target="_blank" rel="noopener">Usage</a>
@@ -330,6 +332,7 @@
   <script src="config.js"></script>
   <script src="languages.js"></script>
   <script src="usageColor.js"></script>
+  <script src="qa/chart.umd.js"></script>
   <script src="popup.js"></script>
   <script src="popup/support.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- import Chart.js in popup
- show request and token sparklines from 24h history

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fdde8a31083238055cf5e582c310c