### PR TITLE
feat: make qwen-mt-plus fallback optional

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -51,8 +51,8 @@ function migrate(cfg = {}) {
   if (!p.costPerToken) p.costPerToken = 0;
   if (!p.weight) p.weight = 0;
   if (!p.strategy) p.strategy = out.strategy || 'balanced';
-  if (Array.isArray(cfg.models)) p.models = cfg.models.slice();
-  else if (!p.models) p.models = p.model ? [p.model] : [];
+  if (Array.isArray(cfg.models) && cfg.models.length) p.models = cfg.models.slice();
+  else if (!p.models || !p.models.length) p.models = p.model ? [p.model] : [];
   if (!p.secondaryModel) {
     p.secondaryModel = p.models.length > 1
       ? p.models.find(m => m !== p.model) || ''

--- a/src/popup.html
+++ b/src/popup.html
@@ -221,6 +221,8 @@
                  title="Provider model identifier (e.g., qwen-mt-turbo, gpt-4o-mini).">
           <small class="help">Translation model name. Higher-tier models cost more.</small>
 
+          <label title="Use qwen-mt-plus if qwen-mt-turbo fails"><input type="checkbox" id="plusFallback"> Enable qwen-mt-plus fallback</label>
+
           <label for="providerPreset">Provider preset</label>
           <select id="providerPreset" title="Pick a preset to auto‑fill endpoint and a typical model. Paste your API key separately.">
             <option value="">— Choose a provider —</option>

--- a/src/popup.js
+++ b/src/popup.js
@@ -2,6 +2,7 @@
 const apiKeyInput = document.getElementById('apiKey') || document.createElement('input');
 const endpointInput = document.getElementById('apiEndpoint') || document.createElement('input');
 const modelInput = document.getElementById('model') || document.createElement('input');
+const plusFallbackCheckbox = document.getElementById('plusFallback') || document.createElement('input');
 const sourceSelect = document.getElementById('source') || document.createElement('select');
 const targetSelect = document.getElementById('target') || document.createElement('select');
 const reqLimitInput = document.getElementById('requestLimit') || document.createElement('input');
@@ -203,12 +204,17 @@ function saveConfig() {
       theme: lightModeCheckbox.checked ? 'light' : 'dark',
       calibratedAt: (window.qwenConfig && window.qwenConfig.calibratedAt) || 0,
     };
-    if (cfg.model === 'qwen-mt-turbo') {
-      cfg.secondaryModel = 'qwen-mt-plus';
-      cfg.models = ['qwen-mt-turbo', 'qwen-mt-plus'];
-    } else if (cfg.model === 'qwen-mt-plus') {
-      cfg.secondaryModel = 'qwen-mt-turbo';
-      cfg.models = ['qwen-mt-plus', 'qwen-mt-turbo'];
+    if (plusFallbackCheckbox.checked) {
+      if (cfg.model === 'qwen-mt-turbo') {
+        cfg.secondaryModel = 'qwen-mt-plus';
+        cfg.models = ['qwen-mt-turbo', 'qwen-mt-plus'];
+      } else if (cfg.model === 'qwen-mt-plus') {
+        cfg.secondaryModel = 'qwen-mt-turbo';
+        cfg.models = ['qwen-mt-plus', 'qwen-mt-turbo'];
+      } else {
+        cfg.secondaryModel = '';
+        cfg.models = cfg.model ? [cfg.model] : [];
+      }
     } else {
       cfg.secondaryModel = '';
       cfg.models = cfg.model ? [cfg.model] : [];
@@ -422,6 +428,7 @@ window.qwenLoadConfig().then(cfg => {
   if (sensitivityInput) sensitivityInput.value = cfg.sensitivity;
   endpointInput.value = cfg.apiEndpoint || '';
   modelInput.value = cfg.model || '';
+  plusFallbackCheckbox.checked = Array.isArray(cfg.models) && cfg.models.includes('qwen-mt-plus');
   sourceSelect.value = cfg.sourceLanguage;
   targetSelect.value = cfg.targetLanguage;
   // Sensible defaults if unset: auto source, target from browser UI language
@@ -471,7 +478,8 @@ window.qwenLoadConfig().then(cfg => {
   });
 
   [reqLimitInput, tokenLimitInput, tokenBudgetInput, memCacheMaxInput, sensitivityInput].forEach(el => el.addEventListener('input', saveConfig));
-  [sourceSelect, targetSelect, autoCheckbox, debugCheckbox, qualityCheckbox].forEach(el => el.addEventListener('change', saveConfig));
+  [sourceSelect, targetSelect, autoCheckbox, debugCheckbox, qualityCheckbox, plusFallbackCheckbox]
+    .forEach(el => el.addEventListener('change', saveConfig));
   compactCheckbox.addEventListener('change', () => {
     document.body.classList.toggle('qwen-compact', compactCheckbox.checked);
     saveConfig();

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -15,6 +15,16 @@ describe('config migration', () => {
     expect(set).toHaveBeenCalled();
   });
 
+  test('does not add qwen-mt-plus fallback by default', async () => {
+    const stored = { model: 'qwen-mt-turbo', provider: 'qwen' };
+    const set = jest.fn((o, cb) => cb && cb());
+    global.chrome = { storage: { sync: { get: (d, cb) => cb({ ...d, ...stored }), set } } };
+    const { qwenLoadConfig } = require('../src/config.js');
+    const cfg = await qwenLoadConfig();
+    expect(cfg.models).toEqual(['qwen-mt-turbo']);
+    expect(cfg.secondaryModel).toBe('');
+  });
+
   test('saves provider specific fields', async () => {
     const set = jest.fn((o, cb) => cb && cb());
     global.chrome = { storage: { sync: { set } } };


### PR DESCRIPTION
## Summary
- add provider option to toggle qwen-mt-plus fallback
- stop migrating/saving configs from inserting qwen-mt-plus automatically
- cover migration without fallback in unit tests

## Testing
- `npm test --ci`

------
https://chatgpt.com/codex/tasks/task_e_689fe5cd7a888323961ed4bc5917b51b