### PR TITLE
Compute ETA from token throughput

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -240,10 +240,11 @@ function _setConfig(c) { config = { ...config, ...c }; }
 function getAggregatedStats() {
   const { totalRequests, totalTokens, tokenLimit, tokens } = self.qwenThrottle.getUsage();
   const remaining = Math.max(0, tokenLimit - tokens);
-  const eta = tokenLimit ? remaining / tokenLimit : 0;
-  const avgLatency = usageLog.length
-    ? usageLog.reduce((sum, e) => sum + (e.latency || 0), 0) / usageLog.length
-    : 0;
+  const totalLatency = usageLog.reduce((sum, e) => sum + (e.latency || 0), 0);
+  const totalLoggedTokens = usageLog.reduce((sum, e) => sum + (e.tokens || 0), 0);
+  const avgThroughput = totalLatency ? (totalLoggedTokens / totalLatency) * 1000 : 0; // tokens per second
+  const eta = avgThroughput ? remaining / avgThroughput : 0;
+  const avgLatency = usageLog.length ? totalLatency / usageLog.length : 0;
   return { requests: totalRequests, tokens: totalTokens, eta, avgLatency, quality: lastQuality };
 }
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -168,6 +168,7 @@
         <div class="usage-item">Total Requests: <span id="statsRequests">0</span></div>
         <div class="usage-item">Total Tokens: <span id="statsTokens">0</span></div>
         <div class="usage-item">Avg Latency: <span id="statsLatency">0</span> ms</div>
+        <div class="usage-item">ETA: <span id="statsEta">0</span> s</div>
         <div class="usage-item">Confidence: <span id="statsQuality">0</span></div>
         <div class="usage-item" style="grid-column: span 2;"><canvas id="reqSpark" height="30" style="width:100%;"></canvas></div>
         <div class="usage-item" style="grid-column: span 2;"><canvas id="tokSpark" height="30" style="width:100%;"></canvas></div>

--- a/src/popup.js
+++ b/src/popup.js
@@ -40,6 +40,7 @@ const clearPairBtn = document.getElementById('clearPair') || document.createElem
 const statsReq = document.getElementById('statsRequests') || document.createElement('span');
 const statsTok = document.getElementById('statsTokens') || document.createElement('span');
 const statsLatency = document.getElementById('statsLatency') || document.createElement('span');
+const statsEta = document.getElementById('statsEta') || document.createElement('span');
 const statsQuality = document.getElementById('statsQuality') || document.createElement('span');
 const statsDetails = document.getElementById('statsDetails') || document.createElement('details');
 const statsSummary = statsDetails.querySelector('summary') || document.createElement('summary');
@@ -341,11 +342,17 @@ chrome.runtime.onMessage.addListener(msg => {
     }
   }
   if (msg.action === 'stats' && msg.stats) {
-    const { requests, tokens, avgLatency, quality } = msg.stats;
+    const { requests, tokens, eta, avgLatency, quality } = msg.stats;
     statsReq.textContent = requests;
     statsTok.textContent = tokens;
     statsLatency.textContent = typeof avgLatency === 'number' ? avgLatency.toFixed(0) : '0';
     statsQuality.textContent = typeof quality === 'number' ? quality.toFixed(2) : '0';
+    if (statsEta) statsEta.textContent = typeof eta === 'number' ? eta.toFixed(1) : '0';
+    if (statsSummary) {
+      statsSummary.textContent = typeof eta === 'number' && !isNaN(eta)
+        ? `Stats · ETA ${eta.toFixed(1)}s`
+        : 'Stats';
+    }
     renderSparklines();
   }
 });
@@ -391,6 +398,12 @@ chrome.runtime.sendMessage({ action: 'get-stats' }, res => {
     statsTok.textContent = res.tokens || 0;
     statsLatency.textContent = typeof res.avgLatency === 'number' ? res.avgLatency.toFixed(0) : '0';
     statsQuality.textContent = typeof res.quality === 'number' ? res.quality.toFixed(2) : '0';
+    if (statsEta) statsEta.textContent = typeof res.eta === 'number' ? res.eta.toFixed(1) : '0';
+    if (statsSummary) {
+      statsSummary.textContent = typeof res.eta === 'number' && !isNaN(res.eta)
+        ? `Stats · ETA ${res.eta.toFixed(1)}s`
+        : 'Stats';
+    }
     renderSparklines();
   }
 });


### PR DESCRIPTION
## Summary
- derive tokens-per-second throughput in `getAggregatedStats` and return ETA in seconds
- show ETA seconds field in popup stats panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fe7d6145c8323ac6823b1c187444b