### PR TITLE
fix: use local background attachment in popup

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -23,7 +23,11 @@
 
     html {
       height: 100%;
-      background: var(--bg-color) url('styles/popup-bg.svg') center/cover no-repeat;
+      background-color: var(--bg-color);
+      background-image: url('styles/popup-bg.svg');
+      background-position: center;
+      background-size: cover;
+      background-repeat: no-repeat;
       background-attachment: local;
     }
 


### PR DESCRIPTION
## Summary
- split popup background definitions and use local attachment so background scrolls with content
- keep body scrollability via min-height and overflow settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe953f57c832383ecbdb2f0f0c82f