### PR TITLE
feat: add provider management link

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -178,6 +178,7 @@
         <div class="usage-item" style="grid-column: span 2;"><canvas id="tokSpark" height="30" style="width:100%;"></canvas></div>
       </div>
     </details>
+    <a id="manageProviders" href="popup/providers.html" target="_blank" rel="noopener" class="secondary btn-frame">Manage Providers (<span id="providerCount"></span>)</a>
     <a href="qa/usage.html" target="_blank" rel="noopener">Usage</a>
 
     <div class="grid-2">

--- a/src/popup.js
+++ b/src/popup.js
@@ -35,6 +35,7 @@ const tmStatsDiv = document.getElementById('tmStats') || document.createElement(
 const translateBtn = document.getElementById('translate') || document.createElement('button');
 const testBtn = document.getElementById('test') || document.createElement('button');
 const progressBar = document.getElementById('progress') || document.createElement('progress');
+const providerCountSpan = document.getElementById('providerCount') || document.createElement('span');
 const providerPreset = document.getElementById('providerPreset') || document.createElement('select');
 const clearPairBtn = document.getElementById('clearPair') || document.createElement('button');
 const statsReq = document.getElementById('statsRequests') || document.createElement('span');
@@ -434,6 +435,7 @@ resetCalibrationBtn.addEventListener('click', () => {
 
 window.qwenLoadConfig().then(cfg => {
   window.qwenConfig = cfg;
+  providerCountSpan.textContent = Object.keys(cfg.providers || {}).length;
   // Populate main view
   apiKeyInput.value = cfg.apiKey || '';
   if (detectApiKeyInput) detectApiKeyInput.value = cfg.detectApiKey || '';


### PR DESCRIPTION
## Summary
- add Manage Providers button linking to provider settings
- show configured provider count next to link

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689feb630bbc83238e4d618e2c4d2518