### PR TITLE
Show benchmark table and apply recommended provider order

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -107,6 +107,9 @@
       from { opacity: 0; transform: translateY(-4px); }
       to { opacity: 1; transform: translateY(0); }
     }
+    .benchmark-table { width: 100%; font-size: 0.75rem; border-collapse: collapse; margin-top: 0.5rem; }
+    .benchmark-table th, .benchmark-table td { padding: 2px 4px; text-align: left; }
+    .benchmark-table tr.recommended { color: var(--green); }
   </style>
 </head>
 <body class="qwen-bg-animated">


### PR DESCRIPTION
## Summary
- render benchmark latency and cost table in popup
- highlight recommended provider and allow applying suggested provider order

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ff1aebaac8323aa6e286c25e169b6