### PR TITLE
Prefill token limit from model selection

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -552,6 +552,18 @@ window.qwenLoadConfig().then(cfg => {
     });
   });
 
+  const tokenLimits = typeof modelTokenLimits === 'object' ? modelTokenLimits : {};
+  const fixedModels = new Set(['qwen-mt-turbo', 'qwen-mt-plus']);
+  [modelInput, setupModelInput].forEach(input => {
+    input.addEventListener('change', () => {
+      const model = input.value.trim();
+      const limit = tokenLimits[model];
+      if (!limit || fixedModels.has(model)) return;
+      tokenLimitInput.value = limit;
+      saveConfig();
+    });
+  });
+
   [reqLimitInput, tokenLimitInput, tokenBudgetInput, memCacheMaxInput, strategySelect].forEach(el => el.addEventListener('input', saveConfig));
   if (sensitivityInput && sensitivityValueSpan) {
     const updateSensitivityValue = () => {


### PR DESCRIPTION
## Summary
- prefill token limit based on modelTokenLimits while leaving qwen-mt-turbo and qwen-mt-plus quotas untouched

## Testing
- `npm test --silent | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689fffbf2f4c8323bee85cacbb0c9ce2