### PR TITLE
feat: add qwen-mt-plus fallback toggle

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -56,18 +56,12 @@ function migrate(cfg = {}) {
     if (p.strategy != null) p.strategy = mapStrategy(p.strategy);
     if (p.strategy == null) p.strategy = mapStrategy(out.strategy || 'balanced');
     if (!Array.isArray(p.models) || !p.models.length) p.models = p.model ? [p.model] : [];
-    if (!p.secondaryModel) {
-      p.secondaryModel = p.models.length > 1
-        ? p.models.find(m => m !== p.model) || ''
-        : '';
-    }
   });
   if (out.apiKey && !out.providers[provider].apiKey) out.providers[provider].apiKey = out.apiKey;
   if (out.apiEndpoint && !out.providers[provider].apiEndpoint) out.providers[provider].apiEndpoint = out.apiEndpoint;
   if (out.model && !out.providers[provider].model) out.providers[provider].model = out.model;
   const p = out.providers[provider];
   if (!Array.isArray(p.models) || !p.models.length) p.models = p.model ? [p.model] : [];
-  if (Array.isArray(cfg.models) && cfg.models.length) p.models = cfg.models.slice();
   out.apiKey = p.apiKey || out.apiKey || '';
   out.apiEndpoint = p.apiEndpoint || out.apiEndpoint || '';
   out.model = p.model || out.model || '';

--- a/src/popup/providers.js
+++ b/src/popup/providers.js
@@ -200,6 +200,8 @@
       }
       if (data.models && data.models.length > 1) {
         data.secondaryModel = data.models.find(m => m !== data.model) || '';
+      } else {
+        data.secondaryModel = '';
       }
       newProviders[id] = data;
     });
@@ -211,6 +213,10 @@
     cfg.providers = newProviders;
     cfg.failover = failoverBox.checked;
     cfg.parallel = parallelBox.value === 'on' ? true : parallelBox.value === 'off' ? false : 'auto';
+    const primary = newProviders[cfg.provider] || {};
+    cfg.model = primary.model || '';
+    cfg.models = primary.models || [];
+    cfg.secondaryModel = primary.secondaryModel || '';
     await window.qwenSaveConfig(cfg);
     status.textContent = 'Saved';
     setTimeout(() => (status.textContent = ''), 1000);


### PR DESCRIPTION
## Summary
- avoid automatic secondary model assignment during config migration
- wire provider settings to clear qwen-mt-plus fallback and sync default provider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0a87298bc832397d72f2369809140