### PR TITLE
feat: expose ETA in stats panel

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -244,15 +244,15 @@ function getAggregatedStats() {
   const totalLatency = usageLog.reduce((sum, e) => sum + (e.latency || 0), 0);
   const totalLoggedTokens = usageLog.reduce((sum, e) => sum + (e.tokens || 0), 0);
   const avgThroughput = totalLatency ? totalLoggedTokens / totalLatency : 0; // tokens per ms
-  const etaMs = avgThroughput ? remaining / avgThroughput : 0;
-  const eta = etaMs / 1000; // seconds
+  const eta = avgThroughput ? (remaining / avgThroughput) / 1000 : 0; // seconds
   const avgLatency = usageLog.length ? totalLatency / usageLog.length : 0;
   return { requests: totalRequests, tokens: totalTokens, eta, avgLatency, quality: lastQuality };
 }
 
 function broadcastStats() {
   ensureThrottle().then(() => {
-    try { chrome.runtime.sendMessage({ action: 'stats', stats: getAggregatedStats() }); } catch {}
+    const stats = getAggregatedStats();
+    try { chrome.runtime.sendMessage({ action: 'stats', stats }); } catch {}
   });
 }
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -46,7 +46,17 @@ const statsLatency = document.getElementById('statsLatency') || document.createE
 const statsEta = document.getElementById('statsEta') || document.createElement('span');
 const statsQuality = document.getElementById('statsQuality') || document.createElement('span');
 const statsDetails = document.getElementById('statsDetails') || document.createElement('details');
-const statsSummary = statsDetails.querySelector('summary') || document.createElement('summary');
+function setStatsSummary(eta) {
+  if (!statsDetails) return;
+  let summary = statsDetails.querySelector('summary');
+  if (!summary) {
+    summary = document.createElement('summary');
+    statsDetails.prepend(summary);
+  }
+  summary.textContent = typeof eta === 'number' && !isNaN(eta)
+    ? `Stats · ETA: ${eta.toFixed(1)} s`
+    : 'Stats';
+}
 const reqSpark = document.getElementById('reqSpark') || document.createElement('canvas');
 const tokSpark = document.getElementById('tokSpark') || document.createElement('canvas');
 const calibrationStatus = document.getElementById('calibrationStatus') || document.createElement('div');
@@ -390,11 +400,7 @@ chrome.runtime.onMessage.addListener(msg => {
     statsLatency.textContent = typeof avgLatency === 'number' ? avgLatency.toFixed(0) : '0';
     statsQuality.textContent = typeof quality === 'number' ? quality.toFixed(2) : '0';
     if (statsEta) statsEta.textContent = typeof eta === 'number' ? eta.toFixed(1) : '0';
-    if (statsSummary) {
-      statsSummary.textContent = typeof eta === 'number' && !isNaN(eta)
-        ? `Stats · ETA: ${eta.toFixed(1)} s`
-        : 'Stats';
-    }
+    setStatsSummary(eta);
     renderSparklines();
   }
   if (msg.action === 'calibration-result' && msg.result) {
@@ -449,11 +455,7 @@ chrome.runtime.sendMessage({ action: 'get-stats' }, res => {
     statsLatency.textContent = typeof res.avgLatency === 'number' ? res.avgLatency.toFixed(0) : '0';
     statsQuality.textContent = typeof res.quality === 'number' ? res.quality.toFixed(2) : '0';
     if (statsEta) statsEta.textContent = typeof res.eta === 'number' ? res.eta.toFixed(1) : '0';
-    if (statsSummary) {
-      statsSummary.textContent = typeof res.eta === 'number' && !isNaN(res.eta)
-        ? `Stats · ETA: ${res.eta.toFixed(1)} s`
-        : 'Stats';
-    }
+    setStatsSummary(res.eta);
     renderSparklines();
   }
 });


### PR DESCRIPTION
## Summary
- include ETA in aggregated stats and send with `stats` message
- show ETA seconds in popup stats summary

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0abdbdf888323a2ac2ac481d42734