### PR TITLE
Add e2e npm script for Playwright tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "jest",
     "build:safari": "bash scripts/convert-safari.sh",
     "test:e2e": "playwright test",
+    "e2e": "npm run test:e2e",
     "postinstall": "bash scripts/fetch-wasm-assets.sh",
     "clean": "rimraf dist",
     "build": "npm run clean && copyfiles -u 1 src/**/* dist",


### PR DESCRIPTION
## Summary
- add `e2e` npm script that runs Playwright tests

## Testing
- `npm test --silent | tail -n 5`
- `npm run e2e --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a0af87070c8323bbbf833b988d284a