### PR TITLE
feat: add OpenAI preset

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -7,9 +7,10 @@ DashScope (Qwen)
 - Notes: Streaming supported (SSE). Background keeps the key.
 
 OpenAI
+- Preset: openai
 - Endpoint: https://api.openai.com/v1
 - Keys: https://platform.openai.com/api-keys
-- Models: gpt-4o-mini (chat/completions)
+- Models: gpt-4o-mini, gpt-4o, gpt-3.5-turbo (chat/completions)
 - Notes: Use a model available to your account. Background keeps the key.
 
 DeepL

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -8,6 +8,7 @@ function initProviders() {
     'deepl-free': require('./deepl').free,
     'deepl-pro': require('./deepl').pro,
     macos: { ...require('./macos'), label: 'macOS' },
+    openai: { ...require('./openai'), label: 'OpenAI' },
     openrouter: { ...require('./openrouter'), label: 'OpenRouter' },
     ollama: { ...require('./ollama'), label: 'Ollama' },
   });


### PR DESCRIPTION
## Summary
- register OpenAI provider with label in default registry
- document OpenAI preset and list supported models

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fc7f315dc83239c232349eeba16b1