### PR TITLE
fix: restore dynamic icon and rate limit recalibration

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -262,7 +262,6 @@ function broadcastEta() {
 
 async function updateIcon() {
   await ensureThrottle();
-  if (typeof OffscreenCanvas === 'undefined') return;
   const { requests, requestLimit, tokens, tokenLimit } = self.qwenThrottle.getUsage();
   const reqPct = requestLimit ? requests / requestLimit : 0;
   const tokPct = tokenLimit ? tokens / tokenLimit : 0;
@@ -270,8 +269,15 @@ async function updateIcon() {
   const busy = activeTranslations > 0;
 
   const size = 128;
-  const c = new OffscreenCanvas(size, size);
-  const ctx = c.getContext('2d');
+  let c, ctx;
+  if (typeof OffscreenCanvas !== 'undefined') {
+    c = new OffscreenCanvas(size, size);
+    ctx = c.getContext('2d');
+  } else if (typeof document !== 'undefined') {
+    c = document.createElement('canvas');
+    c.width = c.height = size;
+    ctx = c.getContext('2d');
+  } else return;
   ctx.clearRect(0, 0, size, size);
 
   // background ring

--- a/src/popup.html
+++ b/src/popup.html
@@ -239,6 +239,20 @@
         </div>
       </details>
 
+      <details id="limitSection" class="panel-frame">
+        <summary>Rate Limits</summary>
+        <div class="form-group" style="padding-top: 0.75rem">
+          <div id="calibrationStatus" class="help"></div>
+          <label for="requestLimit">Request limit/min</label>
+          <input type="number" id="requestLimit" placeholder="60" min="0" title="Maximum translation requests per minute">
+          <label for="tokenLimit">Token limit/min</label>
+          <input type="number" id="tokenLimit" placeholder="100000" min="0" title="Maximum tokens per minute">
+          <label for="tokenBudget">Token budget</label>
+          <input type="number" id="tokenBudget" placeholder="Optional" min="0" title="Optional per-page token budget">
+          <button id="recalibrate" class="secondary btn-frame">Recalibrate</button>
+        </div>
+      </details>
+
       <details id="detectionSection" class="panel-frame">
         <summary>Detection</summary>
         <div class="form-group" style="padding-top: 0.75rem">

--- a/src/popup.js
+++ b/src/popup.js
@@ -66,7 +66,7 @@ const exportGlossaryBtn = document.getElementById('exportGlossary') || document.
 const benchmarkRec = document.getElementById('benchmarkRec') || document.createElement('div');
 
 // Collapsible sections
-const sectionIds = ['providerSection', 'detectionSection', 'cacheSection', 'glossarySection'];
+const sectionIds = ['providerSection', 'limitSection', 'detectionSection', 'cacheSection', 'glossarySection'];
 
   document.body.classList.add('qwen-bg-animated');
   if (translateBtn) translateBtn.classList.add('primary-glow');

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -127,6 +127,35 @@ describe('background icon plus indicator', () => {
     expect(translateSpy).toHaveBeenCalledWith(expect.objectContaining({ noProxy: true }));
     expect(posted.length).toBeGreaterThan(0);
   });
+
+  test('falls back to canvas when OffscreenCanvas missing', async () => {
+    delete global.OffscreenCanvas;
+    const ctx = {
+      clearRect: jest.fn(),
+      lineWidth: 0,
+      strokeStyle: '',
+      beginPath: jest.fn(),
+      arc: jest.fn(),
+      stroke: jest.fn(),
+      fillStyle: '',
+      fill: jest.fn(),
+      getImageData: () => ({}),
+      textAlign: '',
+      textBaseline: '',
+      font: '',
+      fillText: jest.fn(),
+    };
+    const canvas = { width: 0, height: 0, getContext: () => ctx };
+    const createSpy = jest
+      .spyOn(global.document, 'createElement')
+      .mockImplementation(() => canvas);
+    chrome.action.setIcon.mockClear();
+    updateBadge();
+    await Promise.resolve();
+    expect(createSpy).toHaveBeenCalledWith('canvas');
+    expect(chrome.action.setIcon).toHaveBeenCalled();
+    createSpy.mockRestore();
+  });
 });
 
 describe('background cost tracking', () => {


### PR DESCRIPTION
## Summary
- draw action icon using OffscreenCanvas or DOM canvas fallback
- add Rate Limits section with recalibrate button and inputs
- cover icon fallback in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0b3d30790832387efe276257fa06f