### PR TITLE
feat: add Mistral provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See `safari/README.md` for detailed iOS/iPadOS deployment steps.
 
 ## Configuration
 Use the popup to configure:
-- Provider preset to auto-fill endpoint and a typical model (DashScope/Qwen, OpenAI, DeepL)
+- Provider preset to auto-fill endpoint and a typical model (DashScope/Qwen, OpenAI, DeepL, Mistral)
 - API key for your chosen provider (keys are stored locally; never injected into pages)
 - Translation model name (e.g., `qwen-mt-turbo`, `gpt-4o-mini`)
 - Source and target languages (Source can be “Auto-detect”)
@@ -64,6 +64,7 @@ The sample phrase is chosen based on the configured source language so the trans
 ### Where to get API keys
 - DashScope (Qwen): https://dashscope.console.aliyun.com/
 - OpenAI: https://platform.openai.com/api-keys
+- Mistral: https://console.mistral.ai/
 - DeepL: https://www.deepl.com/pro-api
 - Google Cloud (Detection): https://cloud.google.com/translate/docs/setup
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -12,6 +12,12 @@ OpenAI
 - Models: gpt-4o-mini (chat/completions)
 - Notes: Use a model available to your account. Background keeps the key.
 
+Mistral
+- Endpoint: https://api.mistral.ai/v1
+- Keys: https://console.mistral.ai/
+- Models: mistral-small, mistral-medium
+- Notes: Streaming supported (SSE). Custom endpoints allow self-hosted deployments.
+
 DeepL
 - Endpoint: https://api.deepl.com/v2
 - Keys: https://www.deepl.com/pro-api

--- a/src/background.js
+++ b/src/background.js
@@ -1,4 +1,4 @@
-importScripts('lib/logger.js', 'lib/providers.js', 'providers/openai.js', 'providers/openrouter.js', 'providers/deepl.js', 'providers/dashscope.js', 'lib/tm.js', 'lib/feedback.js', 'throttle.js', 'translator.js', 'usageColor.js', 'findLimit.js', 'limitDetector.js', 'backgroundBenchmark.js');
+importScripts('lib/logger.js', 'lib/providers.js', 'providers/openai.js', 'providers/openrouter.js', 'providers/deepl.js', 'providers/dashscope.js', 'providers/mistral.js', 'lib/tm.js', 'lib/feedback.js', 'throttle.js', 'translator.js', 'usageColor.js', 'findLimit.js', 'limitDetector.js', 'backgroundBenchmark.js');
 
 const logger = (self.qwenLogger && self.qwenLogger.create)
   ? self.qwenLogger.create('background')

--- a/src/popup.html
+++ b/src/popup.html
@@ -223,6 +223,7 @@
             <option value="dashscope">DashScope (Qwen)</option>
             <option value="openai">OpenAI</option>
             <option value="openrouter">OpenRouter</option>
+            <option value="mistral">Mistral</option>
             <option value="deepl">DeepL</option>
             <option value="macos">macOS</option>
             <option value="ollama">Ollama</option>
@@ -319,6 +320,7 @@
   <script src="lib/providers.js"></script>
   <script src="providers/openai.js"></script>
   <script src="providers/openrouter.js"></script>
+  <script src="providers/mistral.js"></script>
   <script src="providers/deepl.js"></script>
   <script src="providers/dashscope.js"></script>
   <script src="providers/macos.js"></script>

--- a/src/popup.js
+++ b/src/popup.js
@@ -432,6 +432,7 @@ window.qwenLoadConfig().then(cfg => {
         dashscope: { endpoint: 'https://dashscope-intl.aliyuncs.com/api/v1', model: 'qwen-mt-turbo' },
         openai:    { endpoint: 'https://api.openai.com/v1',                   model: 'gpt-4o-mini' },
         openrouter:{ endpoint: 'https://openrouter.ai/api/v1',               model: 'gpt-4o-mini' },
+        mistral:   { endpoint: 'https://api.mistral.ai/v1',                  model: 'mistral-small' },
         deepl:     { endpoint: 'https://api.deepl.com/v2',                    model: 'deepl' },
         ollama:    { endpoint: 'http://localhost:11434',                     model: 'qwen2:latest' }
       };
@@ -452,6 +453,7 @@ window.qwenLoadConfig().then(cfg => {
       let inferred = '';
       if (v.includes('openai')) inferred = 'openai';
       else if (v.includes('openrouter')) inferred = 'openrouter';
+      else if (v.includes('mistral')) inferred = 'mistral';
       else if (v.includes('deepl')) inferred = 'deepl';
       else if (v.includes('dashscope')) inferred = 'dashscope';
       else if (v.includes('11434') || v.includes('ollama')) inferred = 'ollama';

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -8,6 +8,7 @@ function initProviders() {
     'deepl-free': require('./deepl').free,
     'deepl-pro': require('./deepl').pro,
     macos: { ...require('./macos'), label: 'macOS' },
+    mistral: { ...require('./mistral'), label: 'Mistral' },
     openrouter: { ...require('./openrouter'), label: 'OpenRouter' },
     ollama: { ...require('./ollama'), label: 'Ollama' },
   });

--- a/src/providers/mistral.js
+++ b/src/providers/mistral.js
@@ -1,0 +1,91 @@
+(function (root, factory) {
+  const mod = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
+  else root.qwenProviderMistral = mod;
+}(typeof self !== 'undefined' ? self : this, function (root) {
+  const logger = (root.qwenLogger && root.qwenLogger.create) ? root.qwenLogger.create('provider:mistral') : console;
+  const fetchFn = (typeof fetch !== 'undefined') ? fetch : (root.fetch || null);
+  function withSlash(u) { return /\/$/.test(u) ? u : (u + '/'); }
+
+  async function translate({ endpoint, apiKey, model, text, source, target, signal, debug, onData, stream = true }) {
+    if (!fetchFn) throw new Error('fetch not available');
+    const base = withSlash(endpoint || 'https://api.mistral.ai/v1');
+    const url = base + 'chat/completions';
+    const sys = `You are a professional translator. Translate the user message from ${source} to ${target}. Output only the translation, no explanations.`;
+    const body = { model, messages: [{ role: 'system', content: sys }, { role: 'user', content: text }], stream: !!stream };
+    const headers = { 'Content-Type': 'application/json' };
+    const key = (apiKey || '').trim();
+    if (key) headers.Authorization = /^bearer\s/i.test(key) ? key : `Bearer ${key}`;
+
+    if (debug) {
+      logger.debug('sending translation request to', url);
+      logger.debug('request params', { model, source, target });
+    }
+
+    const resp = await fetchFn(url, { method: 'POST', headers, body: JSON.stringify(body), signal });
+    if (!resp.ok) {
+      let msg = resp.statusText;
+      try { const err = await resp.json(); msg = err.error?.message || msg; } catch {}
+      const error = new Error(`HTTP ${resp.status}: ${msg}`);
+      error.status = resp.status;
+      if (resp.status >= 500 || resp.status === 429) {
+        error.retryable = true;
+        const ra = resp.headers.get('retry-after');
+        if (ra) {
+          const ms = parseInt(ra, 10) * 1000;
+          if (ms > 0) error.retryAfter = ms;
+        }
+        if (resp.status === 429 && !error.retryAfter) error.retryAfter = 60000;
+      }
+      throw error;
+    }
+
+    if (!stream || !resp.body || typeof resp.body.getReader !== 'function') {
+      const data = await resp.json();
+      const out = data.choices?.[0]?.message?.content;
+      if (!out) throw new Error('Invalid API response');
+      return { text: out };
+    }
+
+    // streaming SSE
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let result = '';
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop();
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith('data:')) continue;
+        const data = trimmed.slice(5).trim();
+        if (debug) logger.debug('raw line', data);
+        if (data === '[DONE]') {
+          try { reader.cancel(); } catch {}
+          break;
+        }
+        try {
+          const obj = JSON.parse(data);
+          const chunk = obj.choices?.[0]?.delta?.content || '';
+          if (chunk) {
+            result += chunk;
+            if (onData) onData(chunk);
+            if (debug) logger.debug('chunk received', chunk);
+          }
+        } catch {}
+      }
+    }
+    return { text: result };
+  }
+
+  const provider = { translate, throttle: { requestLimit: 60, windowMs: 60000 } };
+  // Register into provider registry if available
+  try {
+    const reg = root.qwenProviders || (typeof require !== 'undefined' ? require('../lib/providers') : null);
+    if (reg && reg.register && !reg.get('mistral')) reg.register('mistral', provider);
+  } catch {}
+  return provider;
+}));

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -16,6 +16,7 @@ test('listProviders returns name and label', () => {
       { name: 'google', label: 'Google' },
       { name: 'deepl', label: 'DeepL' },
       { name: 'openrouter', label: 'OpenRouter' },
+      { name: 'mistral', label: 'Mistral' },
       { name: 'mock', label: 'Mock Provider' },
     ])
   );


### PR DESCRIPTION
## Summary
- add Mistral provider using api.mistral.ai chat/completions
- expose Mistral preset and script in popup
- document Mistral usage and update provider list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fc7fdd21c83238c41dac9c936bee1