### PR TITLE
feat: add OpenAI preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See `safari/README.md` for detailed iOS/iPadOS deployment steps.
 Use the popup to configure:
 - Provider preset to auto-fill endpoint and a typical model (DashScope/Qwen, OpenAI, DeepL)
 - API key for your chosen provider (keys are stored locally; never injected into pages)
-- Translation model name (e.g., `qwen-mt-turbo`, `gpt-4o-mini`)
+- Translation model name (e.g., `qwen-mt-turbo`, `gpt-5-mini`)
 - Source and target languages (Source can be “Auto-detect”)
 - Detector mode: Local (default, private) or Google (needs a Detection API key)
 - Automatic translation toggle

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -7,9 +7,10 @@ DashScope (Qwen)
 - Notes: Streaming supported (SSE). Background keeps the key.
 
 OpenAI
+- Preset: openai
 - Endpoint: https://api.openai.com/v1
 - Keys: https://platform.openai.com/api-keys
-- Models: gpt-4o-mini (chat/completions)
+- Models: gpt-5, gpt-5-mini, gpt-5-nano (chat/completions)
 - Notes: Use a model available to your account. Background keeps the key.
 
 DeepL

--- a/src/config.js
+++ b/src/config.js
@@ -30,7 +30,7 @@ const defaultCfg = {
 const modelTokenLimits = {
   'qwen-mt-turbo': 31980,
   'qwen-mt-plus': 23797,
-  'gpt-4o-mini': 128000,
+  'gpt-5-mini': 128000,
 };
 
 function migrate(cfg = {}) {

--- a/src/popup.html
+++ b/src/popup.html
@@ -214,7 +214,7 @@
 
           <label for="model">Model</label>
           <input type="text" id="model" placeholder="e.g., qwen-mt-turbo"
-                 title="Provider model identifier (e.g., qwen-mt-turbo, gpt-4o-mini).">
+                 title="Provider model identifier (e.g., qwen-mt-turbo, gpt-5-mini).">
           <small class="help">Translation model name. Higher-tier models cost more.</small>
 
           <label for="providerPreset">Provider preset</label>

--- a/src/popup.js
+++ b/src/popup.js
@@ -430,8 +430,8 @@ window.qwenLoadConfig().then(cfg => {
       if (!v) return;
       const presets = {
         dashscope: { endpoint: 'https://dashscope-intl.aliyuncs.com/api/v1', model: 'qwen-mt-turbo' },
-        openai:    { endpoint: 'https://api.openai.com/v1',                   model: 'gpt-4o-mini' },
-        openrouter:{ endpoint: 'https://openrouter.ai/api/v1',               model: 'gpt-4o-mini' },
+        openai:    { endpoint: 'https://api.openai.com/v1',                   model: 'gpt-5-mini' },
+        openrouter:{ endpoint: 'https://openrouter.ai/api/v1',               model: 'gpt-5-mini' },
         deepl:     { endpoint: 'https://api.deepl.com/v2',                    model: 'deepl' },
         ollama:    { endpoint: 'http://localhost:11434',                     model: 'qwen2:latest' }
       };

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -8,6 +8,7 @@ function initProviders() {
     'deepl-free': require('./deepl').free,
     'deepl-pro': require('./deepl').pro,
     macos: { ...require('./macos'), label: 'macOS' },
+    openai: { ...require('./openai'), label: 'OpenAI' },
     openrouter: { ...require('./openrouter'), label: 'OpenRouter' },
     ollama: { ...require('./ollama'), label: 'Ollama' },
   });


### PR DESCRIPTION
## Summary
- register OpenAI provider with label in default registry
- document OpenAI preset and list gpt-5, gpt-5-mini, gpt-5-nano
- default OpenAI/OpenRouter presets to gpt-5-mini and record token limit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fc7f315dc83239c232349eeba16b1