### PR TITLE
Restore selection context menu and prioritize top of page

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -155,24 +155,35 @@ async function maybeAutoInject(tabId, url) {
   await ensureInjectedAndStart(tabId);
 }
 
+function createContextMenus() {
+  try {
+    chrome.contextMenus.removeAll(() => {
+      chrome.contextMenus.create({
+        id: 'qwen-translate-selection',
+        title: 'Translate selection',
+        contexts: ['selection'],
+      });
+      chrome.contextMenus.create({
+        id: 'qwen-translate-page',
+        title: 'Translate page',
+        contexts: ['page'],
+      });
+      chrome.contextMenus.create({
+        id: 'qwen-enable-site',
+        title: 'Enable auto-translate on this site',
+        contexts: ['page'],
+      });
+    });
+  } catch {}
+}
+
+createContextMenus();
+
 chrome.runtime.onInstalled.addListener(() => {
   logger.info('Qwen Translator installed');
-  chrome.contextMenus.create({
-    id: 'qwen-translate-selection',
-    title: 'Translate selection',
-    contexts: ['selection'],
-  });
-  chrome.contextMenus.create({
-    id: 'qwen-translate-page',
-    title: 'Translate page',
-    contexts: ['page'],
-  });
-  chrome.contextMenus.create({
-    id: 'qwen-enable-site',
-    title: 'Enable auto-translate on this site',
-    contexts: ['page'],
-  });
+  createContextMenus();
 });
+if (chrome.runtime.onStartup) chrome.runtime.onStartup.addListener(createContextMenus);
 
 chrome.contextMenus.onClicked.addListener(async (info, tab) => {
   if (!tab || !tab.id) return;

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -489,9 +489,19 @@ async function start() {
   }
   if (currentConfig.debug) logger.debug('QTDEBUG: starting automatic translation');
   setStatus('Scanning page...');
-  const nodes = [];
-  collectNodes(document.body, nodes);
-  if (nodes.length) batchNodes(nodes);
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
+  const chunk = [];
+  const chunkSize = 200;
+  let node;
+  while ((node = walker.nextNode())) {
+    if (node.textContent.trim() && shouldTranslate(node)) {
+      chunk.push(node);
+      if (chunk.length >= chunkSize) {
+        batchNodes(chunk.splice(0));
+      }
+    }
+  }
+  if (chunk.length) batchNodes(chunk);
   observe();
   if (!batchQueue.length) clearStatus();
 }

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -10,7 +10,7 @@ describe('background icon plus indicator', () => {
         setIcon: jest.fn(),
       },
       runtime: { onInstalled: { addListener: jest.fn() }, onMessage: { addListener: jest.fn() }, onConnect: { addListener: jest.fn() } },
-      contextMenus: { create: jest.fn(), onClicked: { addListener: jest.fn() } },
+      contextMenus: { create: jest.fn(), removeAll: jest.fn(), onClicked: { addListener: jest.fn() } },
       tabs: { onUpdated: { addListener: jest.fn() } },
       storage: {
         sync: { get: (_, cb) => cb({ requestLimit: 60, tokenLimit: 60 }) },
@@ -173,7 +173,7 @@ describe('background cost tracking', () => {
         setIcon: jest.fn(),
       },
       runtime: { onInstalled: { addListener: jest.fn() }, onMessage: { addListener: jest.fn() }, onConnect: { addListener: jest.fn() } },
-      contextMenus: { create: jest.fn(), onClicked: { addListener: jest.fn() } },
+      contextMenus: { create: jest.fn(), removeAll: jest.fn(), onClicked: { addListener: jest.fn() } },
       tabs: { onUpdated: { addListener: jest.fn() } },
       storage: {
         sync: { get: (_, cb) => cb({ requestLimit: 60, tokenLimit: 60 }) },


### PR DESCRIPTION
## Summary
- Recreate context menu entries on service worker start to translate selection, translate page, or enable auto-translate
- Start page translation from the top by scanning the DOM in chunks so early nodes are translated first

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0d40195d48323916a040daf061f99