### PR TITLE
Add DOM batching and cache eviction tests

### DIFF
--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -94,3 +94,14 @@ test('clear cache by domain and language pair', async () => {
   qwenClearCacheLangPair('en', 'es');
   expect(getCache('qwen:en:es:hola')).toBeUndefined();
 });
+
+test('removeCache deletes entry from memory and storage', async () => {
+  const { cacheReady, setCache, getCache, removeCache } = require('../src/cache');
+  await cacheReady;
+  setCache('k1', { text: 'x' });
+  expect(getCache('k1').text).toBe('x');
+  removeCache('k1');
+  expect(getCache('k1')).toBeUndefined();
+  const stored = JSON.parse(localStorage.getItem('qwenCache') || '{}');
+  expect(stored.k1).toBeUndefined();
+});

--- a/test/translator.test.js
+++ b/test/translator.test.js
@@ -29,6 +29,10 @@ beforeEach(() => {
   _setGetUsage(() => getUsage());
 });
 
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 test('translate success', async () => {
   fetch.mockResponseOnce(JSON.stringify({output:{text:'hello'}}));
   const res = await translate({endpoint:'https://example.com/', apiKey:'key', model:'m', text:'hola', source:'es', target:'en'});
@@ -170,11 +174,10 @@ test('rate limiting queues requests', async () => {
   const p2 = translate({ endpoint: 'https://e/', apiKey: 'k', model: 'm', text: '2', source: 'es', target: 'en' });
   const p3 = translate({ endpoint: 'https://e/', apiKey: 'k', model: 'm', text: '3', source: 'es', target: 'en' });
 
-  jest.advanceTimersByTime(1000);
+  await jest.advanceTimersByTimeAsync(1000);
   const res = await Promise.all([p1, p2, p3]);
   expect(res[2].text).toBe('c');
   expect(fetch).toHaveBeenCalledTimes(3);
-  jest.useRealTimers();
 });
 
 test('batch splits requests by token budget', async () => {


### PR DESCRIPTION
## Summary
- test DOM node batching mechanics
- test manual cache eviction
- ensure CI runs coverage via `npm test -- --coverage`
- use fake timers for deterministic content-script tests
- support `models` array and switch model when usage is high
- remove leftover `attempts` variable from translator

## Testing
- `npm test -- --coverage --runInBand`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_689d05193050832391a02d3dcb8ea1e4