### PR TITLE
test: exercise cache eviction and tighten dom batching test

### DIFF
--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -94,3 +94,14 @@ test('clear cache by domain and language pair', async () => {
   qwenClearCacheLangPair('en', 'es');
   expect(getCache('qwen:en:es:hola')).toBeUndefined();
 });
+
+test('removeCache deletes entry from memory and storage', async () => {
+  const { cacheReady, setCache, getCache, removeCache } = require('../src/cache');
+  await cacheReady;
+  setCache('k1', { text: 'x' });
+  expect(getCache('k1').text).toBe('x');
+  removeCache('k1');
+  expect(getCache('k1')).toBeUndefined();
+  const stored = JSON.parse(localStorage.getItem('qwenCache') || '{}');
+  expect(stored.k1).toBeUndefined();
+});

--- a/test/contentScript.test.js
+++ b/test/contentScript.test.js
@@ -104,9 +104,11 @@ test('batches DOM nodes when exceeding token limit', async () => {
   const calls = jest.fn(async ({ texts }) => ({ texts }));
   window.qwenTranslateBatch = calls;
   document.body.innerHTML = '<p>A</p><p>B</p><p>C</p>';
+  jest.useFakeTimers();
   messageListener({ action: 'start' });
-  await new Promise(r => setTimeout(r, 50));
+  await jest.runOnlyPendingTimersAsync();
   expect(calls).toHaveBeenCalledTimes(4);
+  jest.useRealTimers();
   window.qwenTranslateBatch = original;
   delete window.qwenThrottle;
 });
@@ -140,10 +142,12 @@ test('force translation bypasses cache', async () => {
   await translateBatch(nodes);
   expect(network).toHaveBeenCalledTimes(1);
   document.body.innerHTML = '<p><span>Hello</span></p>';
+  jest.useFakeTimers();
   messageListener({ action: 'start', force: true });
-  await new Promise(r => setTimeout(r, 20));
+  await jest.runOnlyPendingTimersAsync();
   expect(network.mock.calls.length).toBeGreaterThan(1);
-  window.qwenTranslateBatch = original;
+  jest.useRealTimers();
+window.qwenTranslateBatch = original;
 });
 
 test('passes provider config to batch translation', async () => {
@@ -193,3 +197,4 @@ test('selection translation threads provider config', async () => {
     endpoints: { x: 'https://x/', y: 'https://y/' },
   }));
 });
+


### PR DESCRIPTION
## Summary
- add unit test covering removeCache behavior in persistent and in-memory stores
- streamline DOM batching test with fake timers
- drop outdated batching scenario after rebase

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e7a1bd4883239ffc19fd84f4160d