### PR TITLE
Fix service worker init and add UI regression tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 
 ## Build, Test, and Development Commands
 - `npm install` once to fetch dependencies.
+- `npx playwright install --with-deps chromium` once to install browsers and system libs for e2e tests.
 - `npm test`: Runs Jest with jsdom and `jest-fetch-mock`.
 - `npm run build`: Copies `src/` to `dist/` (web-accessible assets included).
 - `npm run build:zip`: Produces a reproducible ZIP in `dist/`.
@@ -35,6 +36,8 @@
   - Translator streaming integration; batch read-through; TTL/LRU; in-memory LRU with normalization; mixed-language batching (auto-detect per text and language-clustered groups).
   - TM: TTL + LRU pruning; metrics (hits, misses, sets, evictionsTTL/LRU).
   - Logger redaction: Authorization/apiKey redaction in strings and nested objects.
+  - Background icon status and context menu registration (`test/background.test.js`).
+  - Selection/DOM flows (`e2e/context-menu.spec.js`, `e2e/dom-translate.spec.js`) run via `npm run test:e2e:web`; PDF compare (`e2e/pdf-compare.spec.js`) runs via `npm run test:e2e:pdf`. `npm run test:e2e` executes both suites.
 
 ## Commit & Pull Request Guidelines
 - Commits: imperative, present tense (e.g., "Replace PDF text …"). Optional prefixes `feat:`, `fix:`, `chore:` are welcome when meaningful.
@@ -73,6 +76,9 @@
   - Provider presets (DashScope/OpenAI/DeepL/OpenRouter); provider-specific endpoints/keys/models; version/date shown in popup.
   - Logging via `qwenLogger` with levels and collectors; popup debug output uses the logger.
   - Fetch strategy is centralized in `lib/fetchStrategy.js`; override with `qwenFetchStrategy.setChooser(fn)` for custom proxy/direct routing.
+  - Browser action icon shows quota usage ring and status dot (green active, red error, gray idle); badge reflects active translations.
+  - Context menu entries: "Translate selection", "Translate page", and "Enable auto-translate on this site".
+  - Popup "Test settings" button runs connectivity and translation diagnostics and reports results.
 - Build/CI
   - Reproducible dist + zip; CI builds/tests and uploads artifacts on push/PR.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,20 +14,20 @@
         "pdfjs-dist": "^3.10.111"
       },
       "devDependencies": {
-        "@playwright/test": "^1.45.2",
+        "@playwright/test": "^1.54.2",
         "@types/jest": "^30.0.0",
         "bestzip": "^2.2.1",
         "copyfiles": "^2.4.1",
         "cross-fetch": "^4.1.0",
-        "fake-indexeddb": "^5.0.2",
+        "fake-indexeddb": "^6.1.0",
         "http-server": "^14.1.1",
         "jest": "^30.0.5",
         "jest-environment-jsdom": "^30.0.5",
         "jest-fetch-mock": "^3.0.3",
         "lz-string": "^1.5.0",
         "pdf-lib": "^1.17.1",
-        "rimraf": "^5.0.5",
-        "typescript": "^5.4.5"
+        "rimraf": "^6.0.1",
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -708,6 +708,29 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -3421,9 +3444,9 @@
       }
     },
     "node_modules/fake-indexeddb": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-5.0.2.tgz",
-      "integrity": "sha512-cB507r5T3D55DfclY01GLkninZLfU7HXV/mhVRTnTRm5k2u+fY7Fof2dBkr80p5t7G7dlA/G5dI87QiMdPpMCQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.1.0.tgz",
+      "integrity": "sha512-gOzajWIhEug/CQHUIxigKT9Zilh5/I6WvUBez6/UdUtT/YVEHM9r572Os8wfvhp7TkmgBtRNdqSM7YoCXWMzZg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5804,9 +5827,9 @@
       "license": "0BSD"
     },
     "node_modules/pdfjs-dist": {
-      "version": "3.10.111",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.10.111.tgz",
-      "integrity": "sha512-+SXXGN/3YTNQSK5Ae7EyqQuR+4IAsNunJq/Us5ByOkRJ45qBXXOwkiWi3RIDU+CyF+ak5eSWXl2FQW2PKBrsRA==",
+      "version": "3.11.174",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
+      "integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -6217,16 +6240,103 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^10.3.7"
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
       },
       "bin": {
         "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.0.3",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/jackspeak": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/lru-cache": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "jest",
     "build:safari": "bash scripts/convert-safari.sh",
-    "test:e2e": "playwright test e2e/pdf-compare.spec.js",
+    "test:e2e:web": "playwright test e2e/context-menu.spec.js e2e/dom-translate.spec.js",
+    "test:e2e:pdf": "playwright test e2e/pdf-compare.spec.js",
+    "test:e2e": "npm run test:e2e:web && npm run test:e2e:pdf",
     "e2e": "npm run test:e2e",
     "postinstall": "bash scripts/fetch-wasm-assets.sh",
     "clean": "rimraf dist",
@@ -22,11 +24,11 @@
   "type": "commonjs",
   "types": "types/index.d.ts",
   "devDependencies": {
-    "@playwright/test": "^1.45.2",
+    "@playwright/test": "^1.54.2",
     "@types/jest": "^30.0.0",
     "cross-fetch": "^4.1.0",
     "http-server": "^14.1.1",
-    "fake-indexeddb": "^5.0.2",
+    "fake-indexeddb": "^6.1.0",
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.0.5",
     "jest-fetch-mock": "^3.0.3",
@@ -34,8 +36,8 @@
     "pdf-lib": "^1.17.1",
     "bestzip": "^2.2.1",
     "copyfiles": "^2.4.1",
-    "rimraf": "^5.0.5",
-    "typescript": "^5.4.5"
+    "rimraf": "^6.0.1",
+    "typescript": "^5.9.2"
   },
   "dependencies": {
     "mupdf": "^1.26.4",

--- a/src/limitDetector.js
+++ b/src/limitDetector.js
@@ -1,14 +1,16 @@
-let findLimit;
-if (typeof require !== 'undefined') {
-  findLimit = require('./findLimit');
+let findLimitFn;
+if (typeof findLimit === 'function') {
+  findLimitFn = findLimit;
+} else if (typeof require !== 'undefined') {
+  findLimitFn = require('./findLimit');
 } else if (typeof window !== 'undefined' && window.qwenFindLimit) {
-  findLimit = window.qwenFindLimit;
+  findLimitFn = window.qwenFindLimit;
 } else {
-  findLimit = async () => 0;
+  findLimitFn = async () => 0;
 }
 
 async function detectTokenLimit(translate, { start = 256, max = 8192 } = {}) {
-  return findLimit(async n => {
+  return findLimitFn(async n => {
     const text = 'x'.repeat(n);
     await translate(text);
     return true;
@@ -16,7 +18,7 @@ async function detectTokenLimit(translate, { start = 256, max = 8192 } = {}) {
 }
 
 async function detectRequestLimit(translate, { start = 1, max = 120 } = {}) {
-  return findLimit(async n => {
+  return findLimitFn(async n => {
     for (let i = 0; i < n; i++) {
       try {
         await translate(i);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,9 +18,6 @@
     "https://api.deepl.com/*",
     "https://api-free.deepl.com/*"
   ],
-  "optional_host_permissions": [
-    "file:///*"
-  ],
   "background": {
     "service_worker": "background.js"
   },


### PR DESCRIPTION
## Summary
- prevent `findLimit` redeclaration in limit detector to restore service worker
- remove redundant `optional_host_permissions` entry
- document dynamic icon, context menu, and diagnostics in AGENTS
- add regression tests for action icon status and context menu
- run Playwright selection and DOM translation tests in CI
- split e2e scripts into web and PDF suites
- bump Playwright, fake-indexeddb, rimraf, and TypeScript to latest majors
- note `npx playwright install --with-deps chromium` for local e2e setup

## Testing
- `npm test`
- `npm run test:e2e:web`
- `npm run test:e2e:pdf`


------
https://chatgpt.com/codex/tasks/task_e_68a0f589c1f88323a15b65691baef679