### PR TITLE
fix: redact Error objects

### DIFF
--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -15,6 +15,17 @@
         .replace(/(api[-_\s]?key\s*[:=]\s*).*/ig, '$1<redacted>')
         .replace(/(authorization\s*[:=]\s*).*/ig, '$1<redacted>');
     }
+    if (v instanceof Error) {
+      const out = {};
+      for (const k of Object.getOwnPropertyNames(v)) {
+        if (/^authorization$/i.test(k) || /^api(?:[-_\s]?key)$/i.test(k)) {
+          out[k] = '<redacted>';
+        } else {
+          out[k] = redactValue(v[k]);
+        }
+      }
+      return out;
+    }
     if (Array.isArray(v)) {
       return v.map(redactValue);
     }

--- a/test/logger.redaction.test.js
+++ b/test/logger.redaction.test.js
@@ -25,49 +25,60 @@
      restore();
    });
 
-   test('redacts Authorization and apiKey in strings at all levels', () => {
-     const logger = require('../src/lib/logger.js');
-     const log = logger.create('test');
-     log.setLevel(3); // debug
+  test('redacts Authorization and apiKey in strings at all levels', () => {
+    const logger = require('../src/lib/logger.js');
+    const log = logger.create('test');
+    log.setLevel(3); // debug
 
-     log.debug('Authorization: Bearer abc.123', 'apiKey=xyz-789', 'Api-Key : MYKEY');
-     log.info('authorization=token', 'Api Key: secret');
-     log.warn('Api-Key=Z');
-     log.error('Authorization: Basic foobar');
+    log.debug('Authorization: Bearer abc.123', 'apiKey=xyz-789', 'Api-Key : MYKEY');
+    log.info('authorization=token', 'Api Key: secret');
+    log.warn('Api-Key=Z');
+    log.error('Authorization: Basic foobar');
 
-     const flat = outputs.flatMap(([_, args]) => args.join(' ')).join(' ');
+    const flat = outputs.flatMap(([_, args]) => args.join(' ')).join(' ');
     expect(flat).toMatch(/Authorization\s*[=:]\s*<redacted>/i);
-     expect(flat).toMatch(/api[-_\s]?key\s*[=:]\s*<redacted>/i);
-     expect(flat).not.toMatch(/abc\.123|xyz-789|MYKEY|token|secret|foobar/);
-   });
+    expect(flat).toMatch(/api[-_\s]?key\s*[=:]\s*<redacted>/i);
+    expect(flat).not.toMatch(/abc\.123|xyz-789|MYKEY|token|secret|foobar/);
+  });
 
-   test('redacts values in object/array payloads (shallow and nested)', () => {
-     const logger = require('../src/lib/logger.js');
-     const log = logger.create('test');
-     log.setLevel(3);
+  test('redacts values in object/array payloads (shallow and nested)', () => {
+    const logger = require('../src/lib/logger.js');
+    const log = logger.create('test');
+    log.setLevel(3);
 
-     log.error('oops', {
-       headers: { Authorization: 'Bearer SECRET' },
-       apiKey: 'K',
-       nested: { list: [{ Authorization: 'X' }, { a: 1 }] },
-     });
+    log.error('oops', {
+      headers: { Authorization: 'Bearer SECRET' },
+      apiKey: 'K',
+      nested: { list: [{ Authorization: 'X' }, { a: 1 }] },
+    });
 
-     const payload = outputs.find(([fn]) => fn === 'error')[1][1]; // second arg of error
-     const dumped = JSON.stringify(payload);
-     expect(dumped).toContain('"Authorization":"<redacted>"');
-     expect(dumped).toContain('"apiKey":"<redacted>"');
-     expect(dumped).not.toContain('SECRET');
-     expect(dumped).not.toContain('"X"');
-   });
+    const payload = outputs.find(([fn]) => fn === 'error')[1][1]; // second arg of error
+    const dumped = JSON.stringify(payload);
+    expect(dumped).toContain('"Authorization":"<redacted>"');
+    expect(dumped).toContain('"apiKey":"<redacted>"');
+    expect(dumped).not.toContain('SECRET');
+    expect(dumped).not.toContain('"X"');
+  });
 
-   test('parseLevel handles numbers and strings', () => {
-     const { parseLevel } = require('../src/lib/logger.js');
-     expect(parseLevel('debug')).toBe(3);
-     expect(parseLevel('INFO')).toBe(2);
-     expect(parseLevel('warn')).toBe(1);
-     expect(parseLevel('error')).toBe(0);
-     expect(parseLevel(2)).toBe(2);
-     expect(parseLevel(99)).toBe(3);
-     expect(parseLevel(-1)).toBe(0);
-   });
+  test('preserves Error message and stack with redaction', () => {
+    const logger = require('../src/lib/logger.js');
+    const log = logger.create('test');
+    const err = new Error('Authorization: Bearer SECRET');
+    log.error('fail', err);
+
+    const payload = outputs.find(([fn]) => fn === 'error')[1][1];
+    expect(payload.message).toBe('Authorization: <redacted>');
+    expect(payload.stack).toContain('Authorization: <redacted>');
+  });
+
+  test('parseLevel handles numbers and strings', () => {
+    const { parseLevel } = require('../src/lib/logger.js');
+    expect(parseLevel('debug')).toBe(3);
+    expect(parseLevel('INFO')).toBe(2);
+    expect(parseLevel('warn')).toBe(1);
+    expect(parseLevel('error')).toBe(0);
+    expect(parseLevel(2)).toBe(2);
+    expect(parseLevel(99)).toBe(3);
+    expect(parseLevel(-1)).toBe(0);
+  });
  });


### PR DESCRIPTION
## Summary
- preserve message and stack when redacting Error objects
- cover Error logging in redaction tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1025343c88323be442e625164a5a3