### PR TITLE
feat: translate text from floating selection bubble

### DIFF
--- a/src/styles/apple.css
+++ b/src/styles/apple.css
@@ -111,3 +111,33 @@
 .qwen-hud[data-variant="error"] .qwen-hud__dot {
   background: var(--qwen-error);
 }
+
+.qwen-bubble {
+  position: absolute;
+  z-index: 2147483647;
+  padding: 8px 12px;
+  color: var(--qwen-text);
+  background: var(--qwen-bg);
+  border: 1px solid var(--qwen-border);
+  border-radius: 8px;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  font: 500 12px/1.3 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+  animation: qwen-bubble-fade 0.2s ease-out;
+}
+
+.qwen-bubble__actions {
+  margin-top: 4px;
+  display: flex;
+  gap: 4px;
+}
+
+.qwen-bubble__actions button {
+  padding: 2px 6px;
+  font-size: 11px;
+}
+
+@keyframes qwen-bubble-fade {
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}

--- a/test/contentScript.test.js
+++ b/test/contentScript.test.js
@@ -198,3 +198,30 @@ test('selection translation threads provider config', async () => {
   }));
 });
 
+test('shows bubble on text selection and translates', async () => {
+  const spy = jest.fn(async ({ text }) => ({ text: `T:${text}` }));
+  window.qwenTranslate = spy;
+  setCurrentConfig({
+    apiEndpoint: 'https://e/',
+    model: 'm',
+    sourceLanguage: 'en',
+    targetLanguage: 'es',
+    providerOrder: ['p'],
+    endpoints: { p: 'https://p/' },
+    failover: true,
+    debug: false,
+  });
+  document.body.innerHTML = '<p id="s">Hello</p>';
+  const range = document.createRange();
+  range.selectNodeContents(document.getElementById('s'));
+  const sel = window.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(range);
+  document.dispatchEvent(new MouseEvent('mouseup'));
+  await new Promise(r => setTimeout(r, 0));
+  await new Promise(r => setTimeout(r, 0));
+  const bubble = document.querySelector('.qwen-bubble__result');
+  expect(spy).toHaveBeenCalledWith(expect.objectContaining({ text: 'Hello' }));
+  expect(bubble.textContent).toBe('T:Hello');
+});
+


### PR DESCRIPTION
## Summary
- show translation bubble on text selection and allow pin, copy, or opening the panel
- style bubble with Apple theme animations
- add test for selection bubble translation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1178060908323bd5858a99e2c541d