### PR TITLE
Track cached translations in usage stats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/translator.js
+++ b/src/translator.js
@@ -677,6 +677,8 @@ async function batchOnce({
     if (cache.has(key)) {
       const v = _touchCache(key) || cache.get(key);
       mapping.push({ index: i, chunk: 0, text: v.text, cached: true, lang });
+      stats.words += t.trim().split(/\s+/).filter(Boolean).length;
+      stats.tokens += approxTokens(t);
       return;
     }
     const pieces = splitLongText(t, tokenBudget);

--- a/test/tm.readthrough.test.js
+++ b/test/tm.readthrough.test.js
@@ -67,6 +67,6 @@ describe('TM read-through in batch translation', () => {
     expect(res.texts).toEqual(['TA', 'TB', 'TC']);
     expect(translateMock).not.toHaveBeenCalled();
     expect(res.stats.requests).toBe(0);
-    expect(res.stats.tokens).toBe(0);
+    expect(res.stats.tokens).toBeGreaterThan(0);
   });
 });

--- a/test/translator.cacheStats.test.js
+++ b/test/translator.cacheStats.test.js
@@ -1,0 +1,36 @@
+// @jest-environment node
+
+describe('translator cache stats', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('counts words for cached translations', async () => {
+    const Providers = require('../src/lib/providers.js');
+    Providers.reset();
+    const provider = { translate: jest.fn(async ({ text }) => ({ text: `T:${text}` })) };
+    Providers.register('mock', provider);
+    Providers.init();
+    const tr = require('../src/translator.js');
+    tr.qwenClearCache();
+    await tr.qwenTranslateBatch({
+      texts: ['hello world'],
+      source: 'en',
+      target: 'fr',
+      providerOrder: ['mock'],
+      noProxy: true,
+    });
+    provider.translate.mockClear();
+    const res = await tr.qwenTranslateBatch({
+      texts: ['hello world'],
+      source: 'en',
+      target: 'fr',
+      providerOrder: ['mock'],
+      noProxy: true,
+    });
+    expect(provider.translate).not.toHaveBeenCalled();
+    expect(res.stats.words).toBeGreaterThan(0);
+    expect(res.stats.tokens).toBeGreaterThan(0);
+    expect(res.stats.requests).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- count cached translations toward word and token statistics
- add regression tests for cached translation stats
- update TM read-through test and bump version

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1137db2f08323a014ebf4e528583e