### PR TITLE
Add remote TM sync with diagnostics metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@
   - Auto-detect source via local heuristic; optional Google detection in background using `detectApiKey`.
   - Mixed-language batching: per-text detection and language-clustered requests for accuracy.
 - Caching / TM
-  - TM (IndexedDB) with TTL/LRU and metrics; warmed before batching; skips re-translation of hits.
+  - TM (IndexedDB) with TTL/LRU and metrics; optional chrome.storage.sync/WebDAV/iCloud sync with user toggle and remote clear; warmed before batching; skips re-translation of hits and diagnostics panel shows hit/miss counts.
   - In-memory LRU with normalized keys (whitespace collapsed + NFC) limits memory and improves hit rate.
 - PDF translation
   - Custom viewer (`src/pdfViewer.html/js`) intercepts top-level PDFs and can use provider `translateDocument` (Google, DeepL Pro) or a local WASM pipeline to render translated pages.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/background.js
+++ b/src/background.js
@@ -22,9 +22,10 @@ if (chrome?.storage?.sync) {
 // Load basic config (e.g., memCacheMax) so translator cache limits apply in background
 self.qwenConfig = self.qwenConfig || {};
 try {
-  chrome.storage.sync.get({ memCacheMax: 5000 }, cfg => {
+  chrome.storage.sync.get({ memCacheMax: 5000, tmSync: false }, cfg => {
     const n = parseInt(cfg.memCacheMax, 10);
     if (n > 0) self.qwenConfig.memCacheMax = n;
+    if (self.qwenTM && self.qwenTM.enableSync) { self.qwenTM.enableSync(!!cfg.tmSync); }
   });
 } catch {}
 
@@ -528,6 +529,14 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       });
     }
     if (typeof c.qualityVerify === 'boolean') config.qualityVerify = c.qualityVerify;
+    if (typeof c.tmSync === 'boolean' && self.qwenTM && self.qwenTM.enableSync) {
+      self.qwenTM.enableSync(c.tmSync);
+    }
+    sendResponse({ ok: true });
+    return true;
+  }
+  if (msg.action === 'clear-remote-tm') {
+    if (self.qwenTM && self.qwenTM.clearRemote) { self.qwenTM.clearRemote(); }
     sendResponse({ ok: true });
     return true;
   }

--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,7 @@ const defaultCfg = {
   tokenBudget: 0,
   calibratedAt: 0,
   memCacheMax: 5000,
+  tmSync: false,
   sensitivity: 0.3,
   debug: false,
   qualityVerify: false,
@@ -76,6 +77,7 @@ function migrate(cfg = {}) {
   if (!Array.isArray(out.providerOrder)) out.providerOrder = [];
   if (typeof out.failover !== 'boolean') out.failover = true;
   if (typeof out.parallel !== 'boolean' && out.parallel !== 'auto') out.parallel = 'auto';
+  if (typeof out.tmSync !== 'boolean') out.tmSync = false;
   return out;
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.8.0",
-  "version_name": "2025-08-16",
+  "version": "1.9.0",
+  "version_name": "2025-08-17",
   "permissions": [
     "storage",
     "activeTab",

--- a/src/popup.html
+++ b/src/popup.html
@@ -293,6 +293,9 @@
           <div id="cacheStats" style="font-size:0.75rem"></div>
           <div id="tmStats" style="font-size:0.75rem"></div>
 
+          <label title="Sync translation memory across devices."><input type="checkbox" id="tmSync"> Sync TM</label>
+          <button id="clearRemoteTM">Clear Remote TM</button>
+
           <label title="Enable detailed logs for troubleshooting in DevTools."><input type="checkbox" id="debug"> Debug logging</label>
           <small class="help">Logs extra info to DevTools; slight performance hit.</small>
           <label title="Verify translations with a secondary provider."><input type="checkbox" id="qualityVerify"> Quality verify</label>

--- a/test/popup.test.js
+++ b/test/popup.test.js
@@ -54,6 +54,7 @@ describe('popup configuration test', () => {
           if (msg.action === 'ping') cb({ ok: true });
           else if (msg.action === 'usage') cb({ requests: 0, requestLimit: 60, tokens: 0, tokenLimit: 100000, totalRequests: 0, totalTokens: 0, queue: 0, costs: {} });
           else if (msg.action === 'ensure-start') cb({ ok: true });
+          else if (msg.action === 'debug') cb({ cache: {}, tm: {} });
           else cb && cb({});
         }),
         connect: jest.fn(() => ({ postMessage: jest.fn(), onMessage: { addListener: jest.fn() }, onDisconnect: { addListener: jest.fn() }, disconnect: jest.fn() })),

--- a/test/tm.sync.test.js
+++ b/test/tm.sync.test.js
@@ -1,0 +1,32 @@
+// @jest-environment node
+require('fake-indexeddb/auto');
+
+describe('TM remote sync', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    const data = {};
+    global.chrome = {
+      storage: {
+        sync: {
+          set: jest.fn((obj, cb) => { Object.assign(data, obj); cb && cb(); }),
+          get: jest.fn((keys, cb) => {
+            if (Array.isArray(keys)) { const out = {}; keys.forEach(k => out[k] = data[k]); cb(out); }
+            else cb(data);
+          }),
+          remove: jest.fn((keys, cb) => { (Array.isArray(keys)?keys:[keys]).forEach(k => delete data[k]); cb && cb(); }),
+        },
+      },
+    };
+  });
+
+  test('saves entries to chrome.storage.sync when enabled', async () => {
+    const TM = require('../src/lib/tm.js');
+    await TM.enableSync(true);
+    await TM.set('k', 'v');
+    const res = await new Promise(r => chrome.storage.sync.get(['qwen-tm'], r));
+    expect(Array.isArray(res['qwen-tm'])).toBe(true);
+    await TM.clearRemote();
+    const after = await new Promise(r => chrome.storage.sync.get(['qwen-tm'], r));
+    expect(after['qwen-tm']).toBeUndefined();
+  });
+});

--- a/types/tm.d.ts
+++ b/types/tm.d.ts
@@ -16,11 +16,15 @@ export interface TMStats {
 export declare function get(key: string): Promise<TMEntry | null>;
 export declare function set(key: string, text: string): Promise<void>;
 export declare function stats(): TMStats;
+export declare function enableSync(enable: boolean): Promise<void>;
+export declare function clearRemote(): Promise<void>;
 export declare function __resetStats(): void;
 
 export declare const qwenTM: {
   get: typeof get;
   set: typeof set;
   stats: typeof stats;
+  enableSync: typeof enableSync;
+  clearRemote: typeof clearRemote;
   __resetStats: typeof __resetStats;
 };


### PR DESCRIPTION
## Summary
- allow translation memory to sync via `chrome.storage.sync` or remote backends
- expose TM sync toggle and remote cache clear in popup UI
- show TM hit/miss stats in diagnostics

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a11fe23c3c8323a32d6bdff5daeb39