### PR TITLE
feat: add camera OCR translation page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - Batch delimiter: `src/lib/batchDelim.js` (collision-resistant delimiters).
 - Theme: `src/styles/apple.css` (neutral translucent theme with light/dark variants).
 - Tests: `test/` (Jest). Example: `translator.test.js`.
+- Camera: `src/camera/camera.html/js` (OCR capture with IndexedDB history).
 - Scripts: `scripts/convert-safari.sh` (Safari project generation), `set-config.js` (test config helper).
 - Build artifacts/projects: `safari/` (converter output). PDFs and HTML fixtures for local testing live at repo root (e.g., `test-pdf.html`, `debug-pdf-viewer.html`).
 - Docs: `README.md`, `docs/PROVIDERS.md`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.10.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.10.0",
+      "version": "1.12.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/camera/camera.html
+++ b/src/camera/camera.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html data-qwen-theme="apple">
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="../styles/apple.css">
+  <style>
+    body { margin: 0; background: #000; color: #fff; font-family: sans-serif; display:flex; flex-direction:column; align-items:center; }
+    #preview { position: relative; width: 100%; max-width: 480px; }
+    #camera { width: 100%; height: auto; }
+    #captureCanvas { display:none; }
+    #overlay { position:absolute; top:0; left:0; right:0; background:rgba(0,0,0,0.6); color:#fff; padding:4px; font-size:18px; text-align:center; pointer-events:none; }
+    #history { list-style:none; padding:0; margin:1rem 0 0; width:100%; max-width:480px; }
+    #history li { display:flex; align-items:center; gap:0.5rem; margin-bottom:0.5rem; }
+    #history img { width:64px; height:auto; }
+  </style>
+</head>
+<body>
+  <div id="preview">
+    <video id="camera" autoplay playsinline></video>
+    <canvas id="captureCanvas"></canvas>
+    <div id="overlay"></div>
+  </div>
+  <button id="capture">Capture</button>
+  <ul id="history"></ul>
+
+  <script src="../throttle.js"></script>
+  <script src="../lib/providers.js"></script>
+  <script src="../providers/qwen.js"></script>
+  <script src="../providers/openai.js"></script>
+  <script src="../providers/openrouter.js"></script>
+  <script src="../providers/mistral.js"></script>
+  <script src="../providers/deepl.js"></script>
+  <script src="../providers/dashscope.js"></script>
+  <script src="../providers/macos.js"></script>
+  <script src="../providers/ollama.js"></script>
+  <script src="../lib/messaging.js"></script>
+  <script src="../translator.js"></script>
+  <script src="../config.js"></script>
+  <script src="../languages.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/tesseract.js@4/dist/tesseract.min.js"></script>
+  <script type="module" src="camera.js"></script>
+</body>
+</html>

--- a/src/camera/camera.js
+++ b/src/camera/camera.js
@@ -1,0 +1,111 @@
+(async () => {
+  const video = document.getElementById('camera');
+  const canvas = document.getElementById('captureCanvas');
+  const overlay = document.getElementById('overlay');
+  const captureBtn = document.getElementById('capture');
+  const historyList = document.getElementById('history');
+
+  // Initialize camera stream
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    video.srcObject = stream;
+  } catch (err) {
+    console.error('Camera access denied', err);
+  }
+
+  // IndexedDB setup
+  const dbPromise = new Promise((resolve, reject) => {
+    const req = indexedDB.open('qwen-camera', 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains('captures')) {
+        db.createObjectStore('captures', { keyPath: 'id', autoIncrement: true });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+
+  async function saveCapture(data) {
+    const db = await dbPromise;
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction('captures', 'readwrite');
+      tx.objectStore('captures').add(data);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  async function loadCaptures() {
+    const db = await dbPromise;
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction('captures', 'readonly');
+      const req = tx.objectStore('captures').getAll();
+      req.onsuccess = () => resolve(req.result || []);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  async function renderHistory() {
+    const items = await loadCaptures();
+    historyList.innerHTML = '';
+    items.slice(-5).reverse().forEach(cap => {
+      const li = document.createElement('li');
+      const img = document.createElement('img');
+      img.src = cap.image;
+      const span = document.createElement('span');
+      span.textContent = cap.translation || cap.text;
+      li.appendChild(img);
+      li.appendChild(span);
+      historyList.appendChild(li);
+    });
+  }
+
+  captureBtn.addEventListener('click', async () => {
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    overlay.textContent = 'Recognizing...';
+
+    let ocrText = '';
+    try {
+      const { data } = await Tesseract.recognize(canvas, 'eng');
+      ocrText = (data.text || '').trim();
+    } catch (err) {
+      console.error('OCR failed', err);
+      overlay.textContent = 'OCR failed';
+      return;
+    }
+
+    overlay.textContent = 'Translating...';
+    let translated = '';
+    try {
+      const cfg = await qwenLoadConfig();
+      const res = await qwenTranslate({
+        text: ocrText,
+        source: cfg.sourceLanguage || 'auto',
+        target: cfg.targetLanguage || 'en',
+        providerOrder: cfg.providerOrder,
+        endpoints: cfg.endpoints,
+        failover: cfg.failover,
+        autoInit: true,
+      });
+      translated = res && res.text ? res.text : '';
+      overlay.textContent = translated;
+    } catch (err) {
+      console.error('Translation failed', err);
+      overlay.textContent = 'Translation failed';
+    }
+
+    try {
+      const image = canvas.toDataURL('image/png');
+      await saveCapture({ timestamp: Date.now(), image, text: ocrText, translation: translated });
+      renderHistory();
+    } catch (err) {
+      console.error('Save failed', err);
+    }
+  });
+
+  renderHistory();
+})();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.10.0",
-  "version_name": "2025-08-17",
+  "version": "1.12.0",
+  "version_name": "2025-08-18",
   "permissions": [
     "storage",
     "activeTab",
@@ -22,7 +22,7 @@
     "service_worker": "background.js"
   },
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; base-uri 'none'; frame-ancestors 'self'; connect-src 'self' https: file: blob: data:; img-src 'self' https: file: blob: data:; font-src 'self';"
+    "extension_pages": "script-src 'self' https://cdn.jsdelivr.net 'wasm-unsafe-eval'; object-src 'none'; base-uri 'none'; frame-ancestors 'self'; connect-src 'self' https: file: blob: data:; img-src 'self' https: file: blob: data:; font-src 'self';"
   },
   "action": {
     "default_popup": "popup.html",
@@ -40,6 +40,8 @@
         "lib/glossary.js",
         "throttle.js",
         "styles/apple.css",
+        "camera/camera.html",
+        "camera/camera.js",
         "pdfViewer.html",
         "pdfViewer.js",
         "sessionPdf.js",


### PR DESCRIPTION
## Summary
- add camera capture page with Tesseract OCR, translation overlay, and IndexedDB history
- expose camera resources and allow Tesseract script via CSP update
- bump extension version to 1.12.0

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a124627a2083238e7b33ab1ec05523