### PR TITLE
feat: overlay editable translations in PDF viewer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@
   - In-memory LRU with normalized keys (whitespace collapsed + NFC) limits memory and improves hit rate.
 - PDF translation
   - Custom viewer (`src/pdfViewer.html/js`) intercepts top-level PDFs and can use provider `translateDocument` (Google, DeepL Pro) or a local WASM pipeline to render translated pages.
+  - Viewer parses page layout and overlays editable translated text boxes aligned to original coordinates, with navigation controls.
 - UX and theming
 - Apple HUD (`styles/apple.css`) for in-page status and popup; in-app Getting Started guide; tooltips across fields.
   - Provider presets (DashScope/OpenAI/DeepL/OpenRouter); provider-specific endpoints/keys/models; version/date shown in popup.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "version_name": "2025-08-18",
   "permissions": [
     "storage",

--- a/src/pdfViewer.js
+++ b/src/pdfViewer.js
@@ -59,6 +59,70 @@ import { storePdfInSession, readPdfFromSession } from './sessionPdf.js';
   const zoomOutBtn = document.getElementById('zoomOut');
   const zoomResetBtn = document.getElementById('zoomReset');
   let currentZoom = 1;
+  const pages = [];
+  let currentPageIndex = 0;
+  const translationCache = new Map();
+
+  const navPrev = document.createElement('button');
+  navPrev.id = 'pagePrev';
+  navPrev.textContent = 'Prev';
+  navPrev.className = 'btn';
+  const navNext = document.createElement('button');
+  navNext.id = 'pageNext';
+  navNext.textContent = 'Next';
+  navNext.className = 'btn';
+  const navLabel = document.createElement('span');
+  navLabel.id = 'pageLabel';
+  navLabel.className = 'muted';
+  const navGroup = document.createElement('div');
+  navGroup.className = 'toggle-group';
+  navGroup.appendChild(navPrev);
+  navGroup.appendChild(navNext);
+  const topbar = document.querySelector('.topbar');
+  const zoomControls = document.getElementById('zoomControls');
+  if (topbar && zoomControls) {
+    topbar.insertBefore(navGroup, zoomControls);
+    topbar.insertBefore(navLabel, zoomControls);
+  }
+
+  function updateNav() {
+    navLabel.textContent = `${currentPageIndex + 1}/${pages.length || 1}`;
+    navPrev.disabled = currentPageIndex <= 0;
+    navNext.disabled = currentPageIndex >= pages.length - 1;
+  }
+
+  navPrev.addEventListener('click', () => {
+    if (currentPageIndex > 0) {
+      currentPageIndex--;
+      pages[currentPageIndex].scrollIntoView({ behavior: 'smooth' });
+      updateNav();
+    }
+  });
+  navNext.addEventListener('click', () => {
+    if (currentPageIndex < pages.length - 1) {
+      currentPageIndex++;
+      pages[currentPageIndex].scrollIntoView({ behavior: 'smooth' });
+      updateNav();
+    }
+  });
+
+  viewer.addEventListener('scroll', () => {
+    const scrollTop = viewer.scrollTop;
+    for (let i = 0; i < pages.length; i++) {
+      const p = pages[i];
+      if (scrollTop >= p.offsetTop - 10 && scrollTop < p.offsetTop + p.offsetHeight - 10) {
+        currentPageIndex = i;
+        updateNav();
+        break;
+      }
+    }
+  }, { passive: true });
+
+  updateNav();
+
+  function normText(t) {
+    return String(t == null ? '' : t).replace(/\s+/g, ' ').trim();
+  }
 
   const translateProgress = document.createElement('progress');
   translateProgress.max = 1;
@@ -599,8 +663,86 @@ import { storePdfInSession, readPdfFromSession } from './sessionPdf.js';
         enhanceTextSelection: false,
       });
       await textLayerTask.promise;
+      const transLayer = document.createElement('div');
+      transLayer.className = 'translationLayer';
+      transLayer.style.position = 'absolute';
+      transLayer.style.left = '0';
+      transLayer.style.top = '0';
+      transLayer.style.width = `${viewport.width}px`;
+      transLayer.style.height = `${viewport.height}px`;
+      transLayer.style.zIndex = '20';
+      pageDiv.appendChild(transLayer);
 
-      // Selection enabled via textLayer above; no translation until user clicks regenerate
+      const dedup = new Map();
+      const boxes = [];
+      textContent.items.forEach(item => {
+        const txt = item.str;
+        if (!shouldTranslateLine(txt, cfg)) return;
+        const tr = pdfjsLib.Util.transform(viewport.transform, item.transform);
+        const height = Math.sqrt(tr[1] * tr[1] + tr[3] * tr[3]);
+        const box = {
+          text: txt,
+          left: tr[4],
+          top: tr[5] - height,
+          height,
+          width: item.width,
+        };
+        boxes.push(box);
+        if (translationCache.has(txt)) {
+          box.translated = translationCache.get(txt);
+        } else {
+          if (!dedup.has(txt)) dedup.set(txt, []);
+          dedup.get(txt).push(box);
+        }
+      });
+
+      const uniqueTexts = Array.from(dedup.keys());
+      if (uniqueTexts.length) {
+        const { texts: translated } = await window.qwenTranslateBatch({
+          texts: uniqueTexts,
+          provider: cfg.provider,
+          endpoint: cfg.apiEndpoint,
+          apiKey: cfg.apiKey,
+          model: cfg.model,
+          failover: cfg.failover,
+          source: cfg.sourceLanguage,
+          target: cfg.targetLanguage,
+          debug: cfg.debug,
+        });
+        uniqueTexts.forEach((t, i) => {
+          const out = translated[i];
+          translationCache.set(t, out);
+          dedup.get(t).forEach(b => { b.translated = out; });
+        });
+      }
+
+      boxes.forEach(box => {
+        const div = document.createElement('div');
+        div.textContent = box.translated || '';
+        div.style.position = 'absolute';
+        div.style.left = `${box.left}px`;
+        div.style.top = `${box.top}px`;
+        div.style.fontSize = `${box.height}px`;
+        div.style.whiteSpace = 'pre';
+        div.style.background = 'rgba(255,255,255,0.6)';
+        div.style.color = '#000';
+        div.style.pointerEvents = 'auto';
+        div.contentEditable = 'true';
+        div.addEventListener('blur', () => {
+          const edited = div.textContent || '';
+          translationCache.set(box.text, edited);
+          if (window.qwenTM && window.qwenTM.set) {
+            const key = `${cfg.sourceLanguage}:${cfg.targetLanguage}:${normText(box.text)}`;
+            try { window.qwenTM.set(key, edited); } catch {}
+          }
+        });
+        transLayer.appendChild(div);
+      });
+
+      pages.push(pageDiv);
+      updateNav();
+
+      // Selection enabled via textLayer above; translation overlay rendered
     }
   } catch (e) {
     console.error('Error loading PDF', e);


### PR DESCRIPTION
## Summary
- parse PDF layout and overlay translated text boxes aligned to original coordinates
- reuse TM and glossary to avoid duplicate translation calls
- add page navigation and inline editing controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a126049d9883239182f664b32f569c