### PR TITLE
Add diagnostics panel and background metrics endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/background.js
+++ b/src/background.js
@@ -567,6 +567,28 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     });
     return true;
   }
+  if (msg.action === 'metrics') {
+    ensureThrottle().then(() => {
+      const usage = self.qwenThrottle.getUsage();
+      const cache = {
+        size: self.qwenGetCacheSize ? self.qwenGetCacheSize() : 0,
+        max: (self.qwenConfig && self.qwenConfig.memCacheMax) || 0,
+      };
+      const tm = (self.qwenTM && self.qwenTM.stats) ? self.qwenTM.stats() : {};
+      chrome.storage.sync.get({ providers: {} }, cfg => {
+        const providers = {};
+        Object.entries(cfg.providers || {}).forEach(([id, p]) => {
+          providers[id] = {
+            apiKey: !!p.apiKey,
+            model: p.model || '',
+            endpoint: p.apiEndpoint || '',
+          };
+        });
+        sendResponse({ usage, cache, tm, providers });
+      });
+    });
+    return true;
+  }
   if (msg.action === 'quota') {
     const model = msg.model;
     const cfg = self.qwenConfig || {};

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.13.0",
+  "version": "1.15.0",
   "version_name": "2025-08-18",
   "permissions": [
     "storage",

--- a/src/popup.html
+++ b/src/popup.html
@@ -181,6 +181,7 @@
       </details>
 
     <a href="qa/usage.html" target="_blank" rel="noopener">Usage</a>
+    <a href="popup/diagnostics.html" target="_blank" rel="noopener">Diagnostics</a>
 
       <details class="panel-frame">
         <summary>Getting Started</summary>

--- a/src/popup/diagnostics.html
+++ b/src/popup/diagnostics.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html data-qwen-theme="apple">
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="../styles/apple.css">
+  <style>
+    html { height: 100%; background: var(--qwen-bg, rgba(28,28,30,0.7)); }
+    body { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif; margin:0; padding:1rem; color:var(--qwen-text,#f5f5f7); }
+    ul { list-style: none; padding: 0; }
+    li { margin-bottom: 0.25rem; }
+    .section { margin-bottom: 0.5rem; }
+    pre { white-space: pre-wrap; word-break: break-word; background: var(--qwen-secondary-bg, rgba(118,118,128,0.2)); padding:0.5rem; border-radius:4px; }
+  </style>
+</head>
+<body>
+  <h3>Diagnostics</h3>
+  <div class="section" id="usage"></div>
+  <div class="section" id="cache"></div>
+  <ul id="providers"></ul>
+  <button id="copy" class="primary">Copy Report</button>
+  <script src="diagnostics.js"></script>
+</body>
+</html>
+

--- a/src/popup/diagnostics.js
+++ b/src/popup/diagnostics.js
@@ -1,0 +1,41 @@
+(async function () {
+  const usageEl = document.getElementById('usage');
+  const cacheEl = document.getElementById('cache');
+  const providersEl = document.getElementById('providers');
+  let metrics = {};
+
+  function render() {
+    const u = metrics.usage || {};
+    usageEl.textContent = `Requests ${u.requests || 0}/${u.requestLimit || 0} | Tokens ${u.tokens || 0}/${u.tokenLimit || 0}`;
+    const c = metrics.cache || {};
+    const tm = metrics.tm || {};
+    cacheEl.textContent = `Cache ${c.size || 0}/${c.max || 0} | TM hits ${tm.hits || 0} misses ${tm.misses || 0}`;
+    providersEl.innerHTML = '';
+    Object.entries(metrics.providers || {}).forEach(([id, p]) => {
+      const li = document.createElement('li');
+      li.textContent = `${id}: ${p.apiKey ? 'configured' : 'missing key'}`;
+      providersEl.appendChild(li);
+    });
+  }
+
+  async function load() {
+    if (typeof chrome === 'undefined' || !chrome.runtime?.sendMessage) return;
+    metrics = await new Promise(resolve => chrome.runtime.sendMessage({ action: 'metrics' }, resolve));
+    render();
+  }
+
+  await load();
+
+  document.getElementById('copy').addEventListener('click', async () => {
+    const report = {
+      version: chrome.runtime?.getManifest?.().version,
+      userAgent: navigator.userAgent,
+      metrics,
+    };
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(report, null, 2));
+      cacheEl.textContent += ' (copied)';
+    } catch {}
+  });
+})();
+

--- a/test/background.metrics.test.js
+++ b/test/background.metrics.test.js
@@ -1,0 +1,33 @@
+describe('background metrics endpoint', () => {
+  test('returns usage, cache, tm and provider info', async () => {
+    jest.resetModules();
+    const syncGet = jest.fn((q, cb) => {
+      if (q && Object.prototype.hasOwnProperty.call(q, 'providers')) {
+        cb({ providers: { qwen: { apiKey: 'k', model: 'm', apiEndpoint: 'e' } } });
+      } else {
+        cb({ requestLimit: 10, tokenLimit: 100, memCacheMax: 10, tmSync: false });
+      }
+    });
+    global.chrome = {
+      action: { setBadgeText: jest.fn(), setBadgeBackgroundColor: jest.fn(), setIcon: jest.fn() },
+      runtime: { onInstalled: { addListener: jest.fn() }, onMessage: { addListener: jest.fn() }, onConnect: { addListener: jest.fn() } },
+      contextMenus: { create: jest.fn(), removeAll: jest.fn(cb => cb && cb()), onClicked: { addListener: jest.fn() } },
+      tabs: { onUpdated: { addListener: jest.fn() } },
+      storage: { sync: { get: syncGet }, local: { get: jest.fn(), set: jest.fn() } },
+    };
+    global.importScripts = () => {};
+    global.setInterval = () => {};
+    global.qwenThrottle = { configure: jest.fn(), getUsage: () => ({ requests: 1, requestLimit: 10, tokens: 2, tokenLimit: 100 }) };
+    global.qwenGetCacheSize = () => 5;
+    global.qwenConfig = { memCacheMax: 10 };
+    global.qwenTM = { stats: () => ({ hits: 1, misses: 0 }) };
+    require('../src/background.js');
+    const listener = chrome.runtime.onMessage.addListener.mock.calls[0][0];
+    const res = await new Promise(resolve => listener({ action: 'metrics' }, {}, resolve));
+    expect(res.usage.requests).toBe(1);
+    expect(res.cache.size).toBe(5);
+    expect(res.tm.hits).toBe(1);
+    expect(res.providers.qwen.apiKey).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- expose usage, cache, TM, and provider metrics from background via new `metrics` action
- add diagnostics popup page to view metrics and copy a debug report
- link diagnostics from main popup and bump extension version to 1.15.0

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1c4faf96c8323b17fc262e4da85b1