### PR TITLE
feat: add i18n and keyboard shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -15,6 +15,7 @@ let started = false;
 let progressHud;
 let selectionBubble;
 let selectionPinned = false;
+const i18nReady = window.qwenI18n && window.qwenI18n.ready ? window.qwenI18n.ready : Promise.resolve();
 const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
 let pageRecognizer;
 let prefetchObserver;
@@ -269,29 +270,32 @@ function removeSelectionBubble() {
 async function showSelectionBubble(range, text) {
   removeSelectionBubble();
   selectionPinned = false;
+  await i18nReady;
+  const t = window.qwenI18n ? window.qwenI18n.t.bind(window.qwenI18n) : k => k;
   selectionBubble = document.createElement('div');
   selectionBubble.className = 'qwen-bubble';
   selectionBubble.setAttribute('data-qwen-theme', 'apple');
   selectionBubble.setAttribute('data-qwen-color', (currentConfig && currentConfig.theme) || 'dark');
   selectionBubble.setAttribute('tabindex', '-1');
   selectionBubble.setAttribute('role', 'dialog');
+  selectionBubble.setAttribute('aria-label', t('bubble.ariaLabel'));
   const result = document.createElement('div');
   result.className = 'qwen-bubble__result';
   result.setAttribute('role', 'status');
   result.setAttribute('aria-live', 'polite');
-  result.textContent = 'Translating...';
+  result.textContent = t('bubble.translating');
   selectionBubble.appendChild(result);
   const actions = document.createElement('div');
   actions.className = 'qwen-bubble__actions';
   const pinBtn = document.createElement('button');
-  pinBtn.textContent = 'Pin';
-  pinBtn.setAttribute('aria-label', 'Pin translation');
+  pinBtn.textContent = t('bubble.pin');
+  pinBtn.setAttribute('aria-label', t('bubble.pin'));
   const copyBtn = document.createElement('button');
-  copyBtn.textContent = 'Copy';
-  copyBtn.setAttribute('aria-label', 'Copy translation');
+  copyBtn.textContent = t('bubble.copy');
+  copyBtn.setAttribute('aria-label', t('bubble.copy'));
   const panelBtn = document.createElement('button');
-  panelBtn.textContent = 'Panel';
-  panelBtn.setAttribute('aria-label', 'Open full panel');
+  panelBtn.textContent = t('bubble.panel');
+  panelBtn.setAttribute('aria-label', t('bubble.panel'));
   actions.append(pinBtn, copyBtn, panelBtn);
   selectionBubble.appendChild(actions);
   pinBtn.addEventListener('click', () => {
@@ -756,6 +760,9 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         showError('Translation failed');
       }
     })();
+  }
+  if (msg.action === 'open-panel') {
+    try { chrome.runtime.sendMessage({ action: 'open-panel', text: '', original: '' }); } catch {}
   }
 });
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,13 @@
+{
+  "popup.initialSetup": "Initial Setup",
+  "popup.setupPrompt": "Please configure the essential settings to start using the extension.",
+  "popup.testSettings": "Test Settings",
+  "popup.stats": "Stats",
+  "popup.ariaMain": "Translator settings",
+  "panel.ariaLabel": "Translations",
+  "bubble.translating": "Translating...",
+  "bubble.pin": "Pin",
+  "bubble.copy": "Copy",
+  "bubble.panel": "Panel",
+  "bubble.ariaLabel": "Translation result"
+}

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,0 +1,31 @@
+(function() {
+  const i18n = {
+    messages: {},
+    ready: null,
+    async load() {
+      if (this.ready) return this.ready;
+      const lang = (navigator.language || 'en').split('-')[0];
+      const url = chrome.runtime.getURL(`i18n/${lang}.json`);
+      this.ready = fetch(url)
+        .then(r => r.json())
+        .catch(() => fetch(chrome.runtime.getURL('i18n/en.json')).then(r => r.json()))
+        .then(msgs => { this.messages = msgs; });
+      return this.ready;
+    },
+    t(key) {
+      return this.messages[key] || key;
+    },
+    async apply() {
+      await this.load();
+      document.querySelectorAll('[data-i18n]').forEach(el => {
+        el.textContent = this.t(el.getAttribute('data-i18n'));
+      });
+      document.querySelectorAll('[data-i18n-attr]').forEach(el => {
+        const [attr, key] = el.getAttribute('data-i18n-attr').split(':');
+        el.setAttribute(attr, this.t(key));
+      });
+    }
+  };
+  i18n.load();
+  window.qwenI18n = i18n;
+})();

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -1,0 +1,13 @@
+{
+  "popup.initialSetup": "初始设置",
+  "popup.setupPrompt": "请配置必要设置以开始使用扩展。",
+  "popup.testSettings": "测试设置",
+  "popup.stats": "统计",
+  "popup.ariaMain": "翻译器设置",
+  "panel.ariaLabel": "翻译",
+  "bubble.translating": "翻译中...",
+  "bubble.pin": "固定",
+  "bubble.copy": "复制",
+  "bubble.panel": "面板",
+  "bubble.ariaLabel": "翻译结果"
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.15.0",
-  "version_name": "2025-08-18",
+  "version": "1.16.0",
+  "version_name": "2025-08-19",
   "permissions": [
     "storage",
     "activeTab",
@@ -30,6 +30,16 @@
   },
   "side_panel": {
     "default_path": "panel/panel.html"
+  },
+  "commands": {
+    "translate-selection": {
+      "suggested_key": { "default": "Ctrl+Shift+T" },
+      "description": "Translate selected text"
+    },
+    "open-panel": {
+      "suggested_key": { "default": "Ctrl+Shift+O" },
+      "description": "Open translation panel"
+    }
   },
   "web_accessible_resources": [
     {
@@ -62,9 +72,10 @@
         "wasm/vendor/*",
         "wasm/vendor/fonts/*",
         "config.local.js",
-        "qa/compare.html",
-        "qa/usage.html"
-      ],
+          "qa/compare.html",
+          "qa/usage.html",
+          "i18n/*"
+        ],
       "matches": [
         "<all_urls>"
       ]

--- a/src/panel/panel.html
+++ b/src/panel/panel.html
@@ -10,8 +10,10 @@
     .translated { font-weight: 600; }
   </style>
 </head>
-<body class="qwen-bg qwen-bg-animated">
+<body class="qwen-bg qwen-bg-animated" role="region" data-i18n-attr="aria-label:panel.ariaLabel">
   <div id="translations"></div>
+  <script src="../i18n/index.js"></script>
+  <script>qwenI18n.apply();</script>
   <script src="panel.js"></script>
 </body>
 </html>

--- a/src/popup.html
+++ b/src/popup.html
@@ -110,11 +110,11 @@
   </style>
 </head>
 <body>
-  <div id="viewContainer" class="view-container">
+  <div id="viewContainer" class="view-container" role="main" data-i18n-attr="aria-label:popup.ariaMain">
     <!-- ===== SETUP VIEW ===== -->
     <div class="setup-view">
-      <h3>Initial Setup</h3>
-      <p>Please configure the essential settings to start using the extension.</p>
+      <h3 data-i18n="popup.initialSetup"></h3>
+      <p data-i18n="popup.setupPrompt"></p>
       <div id="benchmarkRec" class="help"></div>
       <div class="form-group">
         <label for="setup-apiKey">API Key</label>
@@ -324,10 +324,10 @@
           <button id="exportGlossary">Export Glossary</button>
         </div>
       </details>
-      <button id="test">Test Settings</button>
+      <button id="test" data-i18n="popup.testSettings"></button>
 
       <details id="statsDetails" open class="panel-frame">
-        <summary>Stats</summary>
+        <summary data-i18n="popup.stats"></summary>
         <div class="usage-section">
           <div class="usage-item">Total Requests: <span id="statsRequests">0</span></div>
           <div class="usage-item">Total Tokens: <span id="statsTokens">0</span></div>
@@ -340,11 +340,13 @@
       </details>
 
       <progress id="progress" value="0" max="1" style="width:100%;display:none"></progress>
-      <div id="status"></div>
+      <div id="status" role="status" aria-live="polite"></div>
       <div id="version"></div>
     </div>
   </div>
 
+  <script src="i18n/index.js"></script>
+  <script>qwenI18n.apply();</script>
   <script src="throttle.js"></script>
   <script src="lib/providers.js"></script>
   <script src="providers/openai.js"></script>


### PR DESCRIPTION
## Summary
- add ARIA roles and i18n to popup, panel, and translation bubble
- expose keyboard shortcuts for translating selection and opening panel
- load locale strings from JSON files per user language

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1c70de1c48323ab04287d428a691a