### PR TITLE
feat: add popup usage monitor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/background.js
+++ b/src/background.js
@@ -273,6 +273,15 @@ function logUsage(tokens, latency) {
   const entry = { ts: Date.now(), tokens, latency };
   usageLog.push(entry);
   safeSendMessage({ action: 'usage-metrics', data: entry });
+  try {
+    chrome.storage.local.get({ usageLog: [] }, data => {
+      const log = data.usageLog || [];
+      log.push(entry);
+      // keep the log from growing without bound
+      if (log.length > 1000) log.shift();
+      chrome.storage.local.set({ usageLog: log });
+    });
+  } catch {}
 }
 
 function setUsingPlus(v) { usingPlus = !!v; }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.19.0",
-  "version_name": "2025-08-17",
+  "version": "1.20.0",
+  "version_name": "2025-08-18",
   "permissions": [
     "storage",
     "activeTab",

--- a/src/popup/home.html
+++ b/src/popup/home.html
@@ -32,6 +32,12 @@
   <label class="auto-toggle"><input type="checkbox" id="autoTranslate"> Auto-translate</label>
   <div id="provider">Provider: <span id="providerName">-</span></div>
   <div id="usage" class="stats">Requests: 0 Tokens: 0</div>
+  <div id="usageSummary" class="stats"></div>
+  <canvas id="usageChart"></canvas>
+  <div id="providerStatus" class="stats"></div>
+  <button id="toDiagnostics" class="secondary">Diagnostics</button>
+  <script src="../qa/chart.umd.js"></script>
+  <script src="monitor.js"></script>
   <script src="home.js"></script>
 </body>
 </html>

--- a/src/popup/monitor.js
+++ b/src/popup/monitor.js
@@ -1,0 +1,64 @@
+(function () {
+  const chartEl = document.getElementById('usageChart');
+  const summaryEl = document.getElementById('usageSummary');
+  const providersEl = document.getElementById('providerStatus');
+  const diagBtn = document.getElementById('toDiagnostics');
+
+  const ctx = chartEl && chartEl.getContext('2d');
+  const chart = ctx && new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: [],
+      datasets: [
+        { label: 'Tokens', data: [], borderColor: 'blue', yAxisID: 'y1' },
+        { label: 'Latency (ms)', data: [], borderColor: 'red', yAxisID: 'y2' }
+      ]
+    },
+    options: {
+      scales: { y1: { type: 'linear', position: 'left' }, y2: { type: 'linear', position: 'right' } }
+    }
+  });
+
+  const log = [];
+
+  function updateSummary() {
+    const requests = log.length;
+    const tokens = log.reduce((s, e) => s + (e.tokens || 0), 0);
+    const avgLatency = log.length ? log.reduce((s, e) => s + (e.latency || 0), 0) / log.length : 0;
+    if (summaryEl) summaryEl.textContent = `Requests: ${requests} Tokens: ${tokens} Avg: ${avgLatency.toFixed(0)}ms`;
+  }
+
+  function addEntry(e) {
+    log.push(e);
+    if (chart) {
+      const label = new Date(e.ts).toLocaleTimeString();
+      chart.data.labels.push(label);
+      chart.data.datasets[0].data.push(e.tokens);
+      chart.data.datasets[1].data.push(e.latency);
+      chart.update();
+    }
+    updateSummary();
+  }
+
+  chrome.storage.local.get({ usageLog: [] }, data => {
+    (data.usageLog || []).forEach(addEntry);
+  });
+
+  chrome.runtime.onMessage.addListener(msg => {
+    if (msg && msg.action === 'usage-metrics' && msg.data) {
+      addEntry(msg.data);
+    }
+  });
+
+  chrome.runtime.sendMessage({ action: 'metrics' }, res => {
+    if (res && res.providers && providersEl) {
+      providersEl.textContent = Object.entries(res.providers)
+        .map(([id, p]) => `${id}: ${p.apiKey ? '✓' : '✗'}`)
+        .join(' ');
+    }
+  });
+
+  diagBtn?.addEventListener('click', () => {
+    location.href = 'diagnostics.html';
+  });
+})();

--- a/test/popupMonitor.test.js
+++ b/test/popupMonitor.test.js
@@ -1,0 +1,33 @@
+// @jest-environment jsdom
+
+describe('monitor summary and providers', () => {
+  let listener;
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <div id="usageSummary"></div>
+      <canvas id="usageChart"></canvas>
+      <div id="providerStatus"></div>
+      <button id="toDiagnostics"></button>
+    `;
+    global.Chart = jest.fn(() => ({ data: { labels: [], datasets: [{ data: [] }, { data: [] }] }, update: jest.fn() }));
+    global.chrome = {
+      storage: { local: { get: jest.fn((_, cb) => cb({ usageLog: [{ ts: 1, tokens: 2, latency: 3 }] })), set: jest.fn() } },
+      runtime: {
+        sendMessage: jest.fn((msg, cb) => { if (msg.action === 'metrics') cb({ providers: { qwen: { apiKey: true } } }); }),
+        onMessage: { addListener: fn => { listener = fn; } }
+      }
+    };
+    require('../src/popup/monitor.js');
+  });
+
+  test('initialises summary and provider status', () => {
+    expect(document.getElementById('usageSummary').textContent).toContain('Requests: 1');
+    expect(document.getElementById('providerStatus').textContent).toContain('qwen');
+  });
+
+  test('updates on usage-metrics message', () => {
+    listener({ action: 'usage-metrics', data: { ts: 2, tokens: 3, latency: 4 } });
+    expect(document.getElementById('usageSummary').textContent).toContain('Requests: 2');
+  });
+});


### PR DESCRIPTION
## Summary
- track requests, tokens and latency in new popup monitor
- persist usage metrics in storage and show provider status
- bump extension version to 1.20.0

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1d33f5a4c83239bf96c7cb328cb92