### PR TITLE
feat: add provider cards with ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/popup/settings.html
+++ b/src/popup/settings.html
@@ -27,6 +27,8 @@
     textarea { width: 100%; }
     .invalid { border-color: #ff4d4f; }
     .note { font-size: 0.8rem; opacity: 0.8; }
+    .provider-card { display: flex; align-items: center; gap: 0.5rem; padding: 0.25rem; border: 1px solid var(--qwen-border, rgba(255,255,255,0.2)); margin-bottom: 0.25rem; }
+    .provider-card .drag-handle { cursor: move; }
   </style>
 </head>
 <body>
@@ -58,7 +60,7 @@
   <div id="providersTab" class="tab">
     <section id="providerSection">
       <h3>Providers</h3>
-      <ul id="providerList"></ul>
+      <div id="providerList" class="provider-cards"></div>
       <button id="addLocalProvider">Add Local Provider</button>
       <div id="localProviderWizard" hidden>
         <label>Type
@@ -103,6 +105,7 @@
     </section>
   </div>
 
+  <script src="../providerConfig.js"></script>
   <script src="../providers/index.js"></script>
   <script src="settings.js"></script>
 </body>

--- a/test/settings.providers.test.js
+++ b/test/settings.providers.test.js
@@ -1,0 +1,70 @@
+// @jest-environment jsdom
+
+function flush() {
+  return new Promise(res => setTimeout(res, 0));
+}
+
+describe('settings provider cards', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <div class="tabs"><button data-tab="general"></button></div>
+      <div id="generalTab">
+        <section id="detectionSection"><input type="checkbox" id="enableDetection"></section>
+        <section id="glossarySection"><textarea id="glossary"></textarea></section>
+        <section id="panelSection"><button id="openPanel"></button></section>
+      </div>
+      <div id="providersTab" class="tab">
+        <section id="providerSection">
+          <div id="providerList"></div>
+          <button id="addLocalProvider"></button>
+          <div id="localProviderWizard"><select id="localProviderType"></select><div id="ollamaForm"></div><div id="macosForm"></div><button id="saveLocalProvider"></button></div>
+        </section>
+      </div>
+      <div id="advancedTab">
+        <section id="limitSection"><input id="requestLimit"><input id="tokenLimit"></section>
+        <section id="cacheSection"><input type="checkbox" id="cacheEnabled"><button id="clearCache"></button></section>
+      </div>
+      <div id="diagnosticsTab"><section id="statsDetails"><pre id="usageStats"></pre></section></div>
+    `;
+    global.chrome = {
+      storage: { sync: { get: jest.fn((defs, cb) => cb(defs)), set: jest.fn() } },
+      runtime: { sendMessage: jest.fn() },
+    };
+    window.qwenProviders = {
+      ensureProviders: jest.fn(),
+      listProviders: jest.fn(() => [{ name: 'p1', label: 'P1' }, { name: 'p2', label: 'P2' }]),
+    };
+    window.qwenProviderConfig = {
+      loadProviderConfig: jest.fn(() => Promise.resolve({ providers: { p1: { enabled: true }, p2: { enabled: true } }, providerOrder: ['p1', 'p2'] })),
+      saveProviderConfig: jest.fn(() => Promise.resolve()),
+    };
+  });
+
+  test('renders provider cards and toggles enabled', async () => {
+    require('../src/popup/settings.js');
+    await flush();
+    const cards = document.querySelectorAll('.provider-card');
+    expect(cards).toHaveLength(2);
+    const cb = cards[0].querySelector('input[type="checkbox"]');
+    cb.checked = false;
+    cb.dispatchEvent(new Event('change'));
+    expect(window.qwenProviderConfig.saveProviderConfig).toHaveBeenCalledWith(expect.objectContaining({
+      providers: expect.objectContaining({ p1: expect.objectContaining({ enabled: false }) }),
+    }));
+  });
+
+  test('saves provider order on dragend', async () => {
+    require('../src/popup/settings.js');
+    await flush();
+    const list = document.getElementById('providerList');
+    const first = list.children[0];
+    const second = list.children[1];
+    list.insertBefore(second, first);
+    first.dispatchEvent(new Event('dragend'));
+    expect(window.qwenProviderConfig.saveProviderConfig).toHaveBeenLastCalledWith(expect.objectContaining({
+      providerOrder: ['p2', 'p1'],
+    }));
+  });
+});
+


### PR DESCRIPTION
## Summary
- replace provider list with draggable provider cards
- persist enabled state and order via provider config
- test provider card toggling and ordering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1d730341c8323be1bf5ad2d45f979