### PR TITLE
feat: add provider editor overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/popup/providerEditor.html
+++ b/src/popup/providerEditor.html
@@ -1,0 +1,11 @@
+<div id="providerEditorOverlay" style="position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.6);display:none;align-items:center;justify-content:center;z-index:1000;">
+  <div style="background:var(--qwen-bg,rgba(28,28,30,0.9));padding:1rem;border:1px solid var(--qwen-border,rgba(255,255,255,0.2));min-width:260px;">
+    <label data-field="apiKey">API Key <input id="pe_apiKey"></label>
+    <label data-field="apiEndpoint">API Endpoint <input id="pe_apiEndpoint"></label>
+    <label data-field="model">Model <input id="pe_model" list="pe_modelList"><datalist id="pe_modelList"></datalist></label>
+    <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-top:0.5rem;">
+      <button id="pe_save">Save</button>
+      <button id="pe_cancel">Cancel</button>
+    </div>
+  </div>
+</div>

--- a/src/popup/providerEditor.js
+++ b/src/popup/providerEditor.js
@@ -1,0 +1,64 @@
+(function(){
+  const overlay = document.getElementById('providerEditorOverlay');
+  const apiKeyEl = overlay.querySelector('#pe_apiKey');
+  const apiEndpointEl = overlay.querySelector('#pe_apiEndpoint');
+  const modelEl = overlay.querySelector('#pe_model');
+  const modelList = overlay.querySelector('#pe_modelList');
+  const saveBtn = overlay.querySelector('#pe_save');
+  const cancelBtn = overlay.querySelector('#pe_cancel');
+  let currentId, cfg, refresh;
+
+  function validUrl(u){
+    if(!u) return true;
+    try{ new URL(u); return true;}catch{return false;}
+  }
+
+  async function open(id, config, onDone){
+    currentId = id;
+    cfg = config;
+    refresh = onDone;
+    const existing = (cfg.providers && cfg.providers[id]) || {};
+    apiKeyEl.value = existing.apiKey || '';
+    apiEndpointEl.value = existing.apiEndpoint || '';
+    modelEl.value = existing.model || '';
+    modelList.innerHTML = '';
+    const prov = window.qwenProviders?.getProvider?.(id);
+    if(prov?.listModels){
+      try {
+        const models = await prov.listModels();
+        models.forEach(m => {
+          const opt = document.createElement('option');
+          opt.value = m;
+          modelList.appendChild(opt);
+        });
+      } catch {}
+    }
+    window.qwenProviderConfig?.applyProviderConfig?.(prov, overlay);
+    overlay.style.display = 'flex';
+  }
+
+  saveBtn.addEventListener('click', () => {
+    const apiEndpoint = apiEndpointEl.value.trim();
+    if(!validUrl(apiEndpoint)){
+      apiEndpointEl.classList.add('invalid');
+      return;
+    }
+    apiEndpointEl.classList.remove('invalid');
+    const providers = cfg.providers || {};
+    providers[currentId] = {
+      ...(providers[currentId] || {}),
+      apiKey: apiKeyEl.value.trim(),
+      apiEndpoint,
+      model: modelEl.value.trim()
+    };
+    window.qwenProviderConfig.saveProviderConfig({...cfg, providers});
+    overlay.style.display = 'none';
+    refresh?.();
+  });
+
+  cancelBtn.addEventListener('click', () => {
+    overlay.style.display = 'none';
+  });
+
+  window.qwenProviderEditor = { open };
+})();

--- a/src/popup/settings.html
+++ b/src/popup/settings.html
@@ -61,6 +61,7 @@
     <section id="providerSection">
       <h3>Providers</h3>
       <div id="providerList" class="provider-cards"></div>
+      <button id="addProvider">Add Provider</button>
       <button id="addLocalProvider">Add Local Provider</button>
       <div id="localProviderWizard" hidden>
         <label>Type


### PR DESCRIPTION
## Summary
- add provider editor overlay with API key, endpoint, and model fields
- wire settings to open overlay for adding or editing providers and persist changes
- bump package version

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1d951f5388323af90b7cb4a6f6077