### PR TITLE
Automate extension release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish Extension
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      EXTENSION_ID: ${{ secrets.EXTENSION_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run build:zip
+      - name: Prepare release assets
+        id: prep
+        run: |
+          VERSION=$(jq -r .version src/manifest.json)
+          ZIP_NAME="qwen-translator-${VERSION}.zip"
+          mv dist/*.zip "dist/${ZIP_NAME}"
+          cat <<XML > dist/updates.xml
+<?xml version="1.0" encoding="UTF-8"?>
+<gupdate xmlns="http://www.google.com/update2/response" protocol="2.0">
+  <app appid="${EXTENSION_ID}">
+    <updatecheck codebase="https://github.com/${GITHUB_REPOSITORY}/releases/download/v${VERSION}/${ZIP_NAME}" version="${VERSION}" />
+  </app>
+</gupdate>
+XML
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "ZIP_NAME=$ZIP_NAME" >> "$GITHUB_OUTPUT"
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.prep.outputs.VERSION }}
+          files: |
+            dist/${{ steps.prep.outputs.ZIP_NAME }}
+            dist/updates.xml
+

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.20.0",
-  "version_name": "2025-08-18",
+  "version": "1.21.0",
+  "version_name": "2025-08-19",
   "permissions": [
     "storage",
     "activeTab",


### PR DESCRIPTION
## Summary
- bump extension version to 1.21.0
- publish zip and updates.xml on every push to main

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1db3cefc48323a52bd3e7860221b9