### PR TITLE
feat: move rate limit to provider editor

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -103,6 +103,7 @@ function qwenSaveConfig(cfg) {
   // Only save if in the Chrome extension context
   if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.sync) {
     const provider = cfg.provider || 'qwen';
+    const num = v => (v === '' || v == null ? undefined : Number(v));
     const providers = { ...(cfg.providers || {}) };
     providers[provider] = {
       ...(providers[provider] || {}),
@@ -111,12 +112,12 @@ function qwenSaveConfig(cfg) {
       model: cfg.model,
       secondaryModel: cfg.secondaryModel,
       models: cfg.models,
-      requestLimit: cfg.requestLimit,
-      tokenLimit: cfg.tokenLimit,
-      charLimit: cfg.charLimit,
+      requestLimit: num(cfg.requestLimit),
+      tokenLimit: num(cfg.tokenLimit),
+      charLimit: num(cfg.charLimit),
       strategy: cfg.strategy,
-      costPerToken: cfg.costPerToken,
-      weight: cfg.weight,
+      costPerToken: num(cfg.costPerToken),
+      weight: num(cfg.weight),
     };
     const toSave = { ...cfg, providers };
     return new Promise((resolve) => {

--- a/src/popup/providerEditor.html
+++ b/src/popup/providerEditor.html
@@ -3,6 +3,15 @@
     <label data-field="apiKey">API Key <input id="pe_apiKey"></label>
     <label data-field="apiEndpoint">API Endpoint <input id="pe_apiEndpoint"></label>
     <label data-field="model">Model <input id="pe_model" list="pe_modelList"><datalist id="pe_modelList"></datalist></label>
+    <details id="pe_advanced">
+      <summary>Advanced</summary>
+      <label data-field="requestLimit">Requests/min <input id="pe_requestLimit" type="number" min="0"></label>
+      <label data-field="tokenLimit">Tokens/min <input id="pe_tokenLimit" type="number" min="0"></label>
+      <label data-field="charLimit">Chars/month <input id="pe_charLimit" type="number" min="0"></label>
+      <label data-field="strategy">Strategy <input id="pe_strategy"></label>
+      <label data-field="costPerToken">Cost/token <input id="pe_costPerToken" type="number" step="0.0001" min="0"></label>
+      <label data-field="weight">Weight <input id="pe_weight" type="number" step="0.01" min="0"></label>
+    </details>
     <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-top:0.5rem;">
       <button id="pe_save">Save</button>
       <button id="pe_cancel">Cancel</button>

--- a/src/popup/providerEditor.js
+++ b/src/popup/providerEditor.js
@@ -4,6 +4,12 @@
   const apiEndpointEl = overlay.querySelector('#pe_apiEndpoint');
   const modelEl = overlay.querySelector('#pe_model');
   const modelList = overlay.querySelector('#pe_modelList');
+  const reqLimitEl = overlay.querySelector('#pe_requestLimit');
+  const tokLimitEl = overlay.querySelector('#pe_tokenLimit');
+  const charLimitEl = overlay.querySelector('#pe_charLimit');
+  const strategyEl = overlay.querySelector('#pe_strategy');
+  const costPerTokenEl = overlay.querySelector('#pe_costPerToken');
+  const weightEl = overlay.querySelector('#pe_weight');
   const saveBtn = overlay.querySelector('#pe_save');
   const cancelBtn = overlay.querySelector('#pe_cancel');
   let currentId, cfg, refresh;
@@ -21,6 +27,12 @@
     apiKeyEl.value = existing.apiKey || '';
     apiEndpointEl.value = existing.apiEndpoint || '';
     modelEl.value = existing.model || '';
+    reqLimitEl.value = existing.requestLimit ?? cfg.requestLimit ?? '';
+    tokLimitEl.value = existing.tokenLimit ?? cfg.tokenLimit ?? '';
+    charLimitEl.value = existing.charLimit ?? cfg.charLimit ?? '';
+    strategyEl.value = existing.strategy || cfg.strategy || '';
+    costPerTokenEl.value = existing.costPerToken ?? cfg.costPerToken ?? '';
+    weightEl.value = existing.weight ?? cfg.weight ?? '';
     modelList.innerHTML = '';
     const prov = window.qwenProviders?.getProvider?.(id);
     if(prov?.listModels){
@@ -45,11 +57,18 @@
     }
     apiEndpointEl.classList.remove('invalid');
     const providers = cfg.providers || {};
+    const num = v => (v === '' ? undefined : Number(v));
     providers[currentId] = {
       ...(providers[currentId] || {}),
       apiKey: apiKeyEl.value.trim(),
       apiEndpoint,
-      model: modelEl.value.trim()
+      model: modelEl.value.trim(),
+      requestLimit: num(reqLimitEl.value.trim()),
+      tokenLimit: num(tokLimitEl.value.trim()),
+      charLimit: num(charLimitEl.value.trim()),
+      strategy: strategyEl.value.trim(),
+      costPerToken: num(costPerTokenEl.value.trim()),
+      weight: num(weightEl.value.trim()),
     };
     window.qwenProviderConfig.saveProviderConfig({...cfg, providers});
     overlay.style.display = 'none';

--- a/src/popup/settings.html
+++ b/src/popup/settings.html
@@ -86,12 +86,6 @@
   </div>
 
   <div id="advancedTab" class="tab">
-    <section id="limitSection">
-      <h3>Rate Limits</h3>
-      <label>Requests/min <input type="number" id="requestLimit" min="0"></label>
-      <label>Tokens/min <input type="number" id="tokenLimit" min="0"></label>
-      <p class="note">Rate limits are known only for Qwen models. Other providers may be unlimited or undocumented. Only Google Translate and DeepL free publish monthly character quotas.</p>
-    </section>
     <section id="cacheSection">
       <h3>Cache</h3>
       <label><input type="checkbox" id="cacheEnabled"> Enable translation memory</label>

--- a/src/popup/settings.js
+++ b/src/popup/settings.js
@@ -1,8 +1,6 @@
 (async function () {
   const defaults = {
     settingsTab: 'general',
-    requestLimit: '',
-    tokenLimit: '',
     enableDetection: true,
     glossary: '',
     cacheEnabled: false,
@@ -39,26 +37,6 @@
   tabs.forEach(btn => btn.addEventListener('click', () => {
     activate(btn.dataset.tab);
     chrome?.storage?.sync?.set({ settingsTab: btn.dataset.tab });
-  }));
-
-  const reqInput = document.getElementById('requestLimit');
-  const tokInput = document.getElementById('tokenLimit');
-  reqInput.value = store.requestLimit;
-  tokInput.value = store.tokenLimit;
-
-  function validateNumber(input) {
-    const v = input.value.trim();
-    if (!v) { input.classList.remove('invalid'); return true; }
-    const n = Number(v);
-    const ok = Number.isFinite(n) && n >= 0;
-    input.classList.toggle('invalid', !ok);
-    return ok;
-  }
-
-  [reqInput, tokInput].forEach(inp => inp.addEventListener('input', () => {
-    if (validateNumber(inp)) {
-      chrome?.storage?.sync?.set({ [inp.id]: inp.value.trim() });
-    }
   }));
 
   const detectBox = document.getElementById('enableDetection');

--- a/src/providerConfig.js
+++ b/src/providerConfig.js
@@ -1,5 +1,13 @@
 function applyProviderConfig(provider, doc = document) {
-  const fields = (provider && provider.configFields) || ['apiKey', 'apiEndpoint', 'model'];
+  const advanced = [
+    'requestLimit',
+    'tokenLimit',
+    'charLimit',
+    'strategy',
+    'costPerToken',
+    'weight',
+  ];
+  const fields = ((provider && provider.configFields) || ['apiKey', 'apiEndpoint', 'model']).concat(advanced);
   const all = [
     'apiKey',
     'apiEndpoint',
@@ -9,6 +17,7 @@ function applyProviderConfig(provider, doc = document) {
     'documentModel',
     'secondaryModel',
     'secondaryModelWarning',
+    ...advanced,
   ];
   all.forEach(name => {
     const show = fields.includes(name);
@@ -28,6 +37,12 @@ function loadProviderConfig() {
     model: '',
     models: [],
     secondaryModel: '',
+    requestLimit: undefined,
+    tokenLimit: undefined,
+    charLimit: undefined,
+    strategy: undefined,
+    costPerToken: undefined,
+    weight: undefined,
   };
   if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.sync) {
     return new Promise(resolve => {


### PR DESCRIPTION
## Summary
- add collapsible Advanced section in provider editor for per-provider rate and cost settings
- persist new provider fields and drop global rate-limit inputs

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68a1db0a4238832390eff34cfdcb1a0b