### PR TITLE
Improve popup navigation and quota visibility

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "version_name": "2025-08-20",
   "update_url": "https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/updates.xml",
   "permissions": [

--- a/src/popup.html
+++ b/src/popup.html
@@ -12,11 +12,14 @@
       color: var(--qwen-text, #f5f5f7);
       width: 380px;
       margin: 0;
+      position: relative;
     }
     #nav {
-      display: flex;
-      justify-content: flex-end;
+      position: absolute;
+      top: 0;
+      right: 0;
       padding: 0.5rem;
+      z-index: 10;
     }
     #nav button {
       background: none;
@@ -28,7 +31,7 @@
     #content {
       width: 100%;
       border: 0;
-      height: calc(100vh - 40px);
+      height: 100vh;
     }
   </style>
 </head>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,13 +1,15 @@
 (function () {
   const frame = document.getElementById('content');
   const settingsBtn = document.getElementById('settingsBtn');
+  let current = 'home.html';
 
   function load(page) {
     if (frame) frame.src = `popup/${page}`;
+    current = page;
   }
 
   settingsBtn?.addEventListener('click', () => {
-    chrome.runtime.sendMessage({ action: 'navigate', page: 'settings' });
+    load(current === 'settings.html' ? 'home.html' : 'settings.html');
   });
 
   chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {

--- a/src/popup/diagnostics.html
+++ b/src/popup/diagnostics.html
@@ -17,6 +17,7 @@
   <div class="section" id="usage"></div>
   <div class="section" id="cache"></div>
   <ul id="providers"></ul>
+  <button id="back" class="secondary">Back</button>
   <button id="copy" class="primary">Copy Report</button>
   <script src="diagnostics.js"></script>
 </body>

--- a/src/popup/diagnostics.js
+++ b/src/popup/diagnostics.js
@@ -2,6 +2,7 @@
   const usageEl = document.getElementById('usage');
   const cacheEl = document.getElementById('cache');
   const providersEl = document.getElementById('providers');
+  const backBtn = document.getElementById('back');
   let metrics = {};
 
   function render() {
@@ -25,6 +26,8 @@
   }
 
   await load();
+
+  backBtn?.addEventListener('click', () => { location.href = 'home.html'; });
 
   document.getElementById('copy').addEventListener('click', async () => {
     const report = {

--- a/src/popup/home.html
+++ b/src/popup/home.html
@@ -22,6 +22,14 @@
       gap: 0.5rem;
       font-size: 0.875rem;
     }
+    .lang-select {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+    .lang-select select {
+      flex: 1;
+    }
     .stats {
       font-size: 0.75rem;
     }
@@ -29,13 +37,20 @@
 </head>
 <body>
   <button id="quickTranslate" class="primary">Quick translate</button>
+  <div class="lang-select">
+    <select id="srcLang"></select>
+    <span>→</span>
+    <select id="destLang"></select>
+  </div>
   <label class="auto-toggle"><input type="checkbox" id="autoTranslate"> Auto-translate</label>
   <div id="provider">Provider: <span id="providerName">-</span></div>
-  <div id="usage" class="stats">Requests: 0 Tokens: 0</div>
+  <div id="usage" class="stats">Requests: 0/0 Tokens: 0/0</div>
+  <div id="limits" class="stats"></div>
   <div id="usageSummary" class="stats"></div>
   <canvas id="usageChart"></canvas>
   <div id="providerStatus" class="stats"></div>
   <button id="toDiagnostics" class="secondary">Diagnostics</button>
+  <script src="../languages.js"></script>
   <script src="../qa/chart.umd.js"></script>
   <script src="monitor.js"></script>
   <script src="home.js"></script>

--- a/src/popup/home.js
+++ b/src/popup/home.js
@@ -3,6 +3,42 @@
   const autoToggle = document.getElementById('autoTranslate');
   const providerName = document.getElementById('providerName');
   const usageEl = document.getElementById('usage');
+  const limitsEl = document.getElementById('limits');
+  const srcSel = document.getElementById('srcLang');
+  const destSel = document.getElementById('destLang');
+
+  const languages = (window.qwenLanguages || []).slice();
+  function fillSelect(sel, allowAuto) {
+    if (!sel) return;
+    if (allowAuto) {
+      const opt = document.createElement('option');
+      opt.value = 'auto';
+      opt.textContent = 'Auto';
+      sel.appendChild(opt);
+    }
+    languages.forEach(l => {
+      const opt = document.createElement('option');
+      opt.value = l.code;
+      opt.textContent = l.name;
+      sel.appendChild(opt);
+    });
+  }
+  fillSelect(srcSel, true);
+  fillSelect(destSel);
+
+  chrome.storage?.sync?.get({ sourceLanguage: 'auto', targetLanguage: 'en' }, cfg => {
+    if (srcSel) srcSel.value = cfg.sourceLanguage;
+    if (destSel) destSel.value = cfg.targetLanguage;
+  });
+
+  srcSel?.addEventListener('change', e => {
+    chrome.storage?.sync?.set({ sourceLanguage: e.target.value });
+    chrome.runtime.sendMessage({ action: 'set-config', config: { sourceLanguage: e.target.value } });
+  });
+  destSel?.addEventListener('change', e => {
+    chrome.storage?.sync?.set({ targetLanguage: e.target.value });
+    chrome.runtime.sendMessage({ action: 'set-config', config: { targetLanguage: e.target.value } });
+  });
 
   quickBtn?.addEventListener('click', () => {
     chrome.runtime.sendMessage({ action: 'home:quick-translate' });
@@ -16,14 +52,16 @@
     if (!res) return;
     providerName.textContent = res.provider || '-';
     const u = res.usage || {};
-    usageEl.textContent = `Requests: ${u.requests || 0} Tokens: ${u.tokens || 0}`;
+    usageEl.textContent = `Requests: ${u.requests || 0}/${u.requestLimit || 0} Tokens: ${u.tokens || 0}/${u.tokenLimit || 0}`;
+    if (limitsEl) limitsEl.textContent = `Queue: ${u.queue || 0}`;
     autoToggle.checked = !!res.auto;
   });
 
   chrome.runtime.onMessage.addListener(msg => {
     if (msg && msg.action === 'home:update-usage') {
       const u = msg.usage || {};
-      usageEl.textContent = `Requests: ${u.requests || 0} Tokens: ${u.tokens || 0}`;
+      usageEl.textContent = `Requests: ${u.requests || 0}/${u.requestLimit || 0} Tokens: ${u.tokens || 0}/${u.tokenLimit || 0}`;
+      if (limitsEl) limitsEl.textContent = `Queue: ${u.queue || 0}`;
     }
   });
 })();

--- a/test/popup.test.js
+++ b/test/popup.test.js
@@ -28,10 +28,12 @@ describe('popup shell routing', () => {
 
   test('routes navigation and home actions', () => {
     require('../src/popup.js');
-    document.getElementById('settingsBtn').click();
-    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'navigate', page: 'settings' });
-
     const frame = document.getElementById('content');
+    document.getElementById('settingsBtn').click();
+    expect(frame.src).toContain('popup/settings.html');
+    document.getElementById('settingsBtn').click();
+    expect(frame.src).toContain('popup/home.html');
+
     listener({ action: 'navigate', page: 'settings' });
     expect(frame.src).toContain('popup/settings.html');
 

--- a/test/popupCache.test.js
+++ b/test/popupCache.test.js
@@ -8,24 +8,31 @@ describe('home usage updates', () => {
       <button id="quickTranslate"></button>
       <label><input type="checkbox" id="autoTranslate"></label>
       <div id="provider">Provider: <span id="providerName"></span></div>
-      <div id="usage">Requests: 0 Tokens: 0</div>
+      <div id="usage">Requests: 0/0 Tokens: 0/0</div>
+      <div id="limits"></div>
     `;
     listener = undefined;
     global.chrome = {
       runtime: {
         sendMessage: jest.fn((msg, cb) => {
-          if (msg.action === 'home:init') cb({ provider: 'p', usage: { requests: 1, tokens: 2 }, auto: false });
+          if (msg.action === 'home:init') cb({ provider: 'p', usage: { requests: 1, tokens: 2, requestLimit: 10, tokenLimit: 20, queue: 0 }, auto: false });
         }),
         onMessage: { addListener: fn => { listener = fn; } },
+      },
+      storage: {
+        sync: {
+          get: jest.fn((defaults, cb) => cb(defaults)),
+          set: jest.fn(),
+        },
       },
     };
     require('../src/popup/home.js');
   });
 
   test('updates usage on runtime message', () => {
-    expect(document.getElementById('usage').textContent).toBe('Requests: 1 Tokens: 2');
-    listener({ action: 'home:update-usage', usage: { requests: 3, tokens: 4 } });
-    expect(document.getElementById('usage').textContent).toBe('Requests: 3 Tokens: 4');
+    expect(document.getElementById('usage').textContent).toBe('Requests: 1/10 Tokens: 2/20');
+    listener({ action: 'home:update-usage', usage: { requests: 3, tokens: 4, requestLimit: 10, tokenLimit: 20, queue: 1 } });
+    expect(document.getElementById('usage').textContent).toBe('Requests: 3/10 Tokens: 4/20');
   });
 });
 

--- a/test/popupCost.test.js
+++ b/test/popupCost.test.js
@@ -7,24 +7,31 @@ describe('home view display', () => {
       <button id="quickTranslate"></button>
       <label><input type="checkbox" id="autoTranslate"></label>
       <div id="provider">Provider: <span id="providerName"></span></div>
-      <div id="usage">Requests: 0 Tokens: 0</div>
+      <div id="usage">Requests: 0/0 Tokens: 0/0</div>
+      <div id="limits"></div>
     `;
     global.chrome = {
       runtime: {
         sendMessage: jest.fn(),
         onMessage: { addListener: jest.fn() },
       },
+      storage: {
+        sync: {
+          get: jest.fn((defaults, cb) => cb(defaults)),
+          set: jest.fn(),
+        },
+      },
     };
   });
 
   test('initializes and handles actions', () => {
     chrome.runtime.sendMessage.mockImplementation((msg, cb) => {
-      if (msg.action === 'home:init') cb({ provider: 'qwen', usage: { requests: 5, tokens: 10 }, auto: false });
+      if (msg.action === 'home:init') cb({ provider: 'qwen', usage: { requests: 5, tokens: 10, requestLimit: 100, tokenLimit: 200, queue: 0 }, auto: false });
     });
     require('../src/popup/home.js');
     expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'home:init' }, expect.any(Function));
     expect(document.getElementById('providerName').textContent).toBe('qwen');
-    expect(document.getElementById('usage').textContent).toBe('Requests: 5 Tokens: 10');
+    expect(document.getElementById('usage').textContent).toBe('Requests: 5/100 Tokens: 10/200');
 
     document.getElementById('quickTranslate').click();
     expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'home:quick-translate' });


### PR DESCRIPTION
## Summary
- Remove empty header bar and make settings button toggle between home and settings
- Add source/target language selectors and show request/token limits on the home view
- Provide back navigation from diagnostics page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0d1239bfc832385a3907a382bab51