### PR TITLE
Support separate input and output token costs and manual selection bubble

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@
 - Background-only keys: content scripts never send/hold API keys; background injects keys for direct and Port flows.
 - Separate detection key: `detectApiKey` (Google) is used only for language detection; translation uses provider keys.
 - Provider-specific keys supported: `apiKeyDashScope`, `apiKeyOpenAI`, `apiKeyDeepL` (fallback to `apiKey` if unset). Background chooses the correct key per provider.
-- Additional fields: per-provider `charLimit`, `requestLimit`, `tokenLimit`, `costPerToken`, `weight` and `strategy` guide cost tracking and load balancing. Google translation also requires `projectId` and `location`, and `secondaryModel` enables quota fallback.
+- Additional fields: per-provider `charLimit`, `requestLimit`, `tokenLimit`, `costPerInputToken`, `costPerOutputToken`, `weight` and `strategy` guide cost tracking and load balancing. Google translation also requires `projectId` and `location`, and `secondaryModel` enables quota fallback.
 - Ensure `styles/apple.css` is listed in `web_accessible_resources` for content <link> fallback.
 
 ## Current Product State
@@ -78,7 +78,7 @@
 - Providers are no longer auto-registered; call `qwenProviders.initProviders()` before translating when using built-ins. `qwenProviders.isInitialized()` reports whether defaults are loaded and the translator now logs a warning if a translation is attempted before initialization. Custom providers can create isolated registries via `qwenProviders.createRegistry()` and register prior to initialization to override or augment the defaults.
  - Providers are no longer auto-registered; call `qwenProviders.initProviders()` or `qwenProviders.ensureProviders()` before translating when using built-ins. `qwenProviders.isInitialized()` reports whether defaults are loaded and the translator now logs a one-time warning if a translation is attempted before initialization. Pass `{ autoInit: true }` to translation calls to invoke `initProviders()` on demand. Custom providers can create isolated registries via `qwenProviders.createRegistry()` and register prior to initialization to override or augment the defaults.
   - Provider order (`providerOrder`) and per-provider endpoints configurable; failover implemented with per-provider `runWithRetry` + rate-limit. Providers may include a `throttle` config to tune request/token limits per backend, with optional per-context queues (e.g., `stream`) for finer control.
-  - Default config assumes roughly 500k free characters for Google/DeepL and tracks spend via `costPerToken`. Background selects providers above `requestThreshold` and uses per-provider weights to balance load across those with available quota.
+  - Default config assumes roughly 500k free characters for Google/DeepL and tracks spend via `costPerInputToken`/`costPerOutputToken`. Background selects providers above `requestThreshold` and uses per-provider weights to balance load across those with available quota.
   - Background pulls provider-specific keys from storage (`getProviderApiKeyFromStorage`) and injects them on both direct and Port paths.
 - Messaging and streaming
   - Port-based background proxy with chunk relay and cancellation; legacy `sendMessage` fallback.
@@ -100,6 +100,7 @@
   - Fetch strategy is centralized in `lib/fetchStrategy.js`; override with `qwenFetchStrategy.setChooser(fn)` for custom proxy/direct routing.
   - Browser action icon shows quota usage ring and status dot (green active, red error, gray idle); badge reflects active translations.
   - Context menu entries: "Translate selection", "Translate page", and "Enable auto-translate on this site".
+  - Selection bubble is disabled by default; enabling it adds a manual translate button when text is selected.
   - Popup "Test settings" button runs connectivity and translation diagnostics and reports results.
   - Auto-translate only starts for the active tab; background tabs remain untouched until activated.
   - Experimental conversation panel streams chat translations in real time; open it from Settings > General.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See also: docs/PROVIDERS.md
 
 ## Usage
 1. Click the toolbar icon to open the popup.
-2. Use **Quick translate** to translate the current tab or enable **Auto-translate** for pages on load.
+2. Use **Translate page** to translate the current tab or enable **Auto-translate** for pages on load.
 3. Click the ⚙️ button to manage providers or adjust settings.
 
 Translations apply to dynamically added content as well as embedded frames or third‑party widgets whenever the browser grants access. If translation fails the affected text is kept in a queue and retried until the API succeeds. When the translated text matches the original the node is marked as untranslatable and skipped. Translations are cached for the current session to minimise API calls.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.23.1",
+  "version": "1.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.23.1",
+      "version": "1.27.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.23.1",
+  "version": "1.27.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/backgroundBenchmark.js
+++ b/src/backgroundBenchmark.js
@@ -33,7 +33,9 @@
         });
         const latency = Date.now() - start;
         const tokens = root.qwenThrottle ? root.qwenThrottle.approxTokens('hello world') : 0;
-        const costPerToken = cfg.costPerToken || COST_RATES[name] || 0;
+        const costIn = (cfg.costPerInputToken ?? cfg.costPerToken ?? COST_RATES[name]) || 0;
+        const costOut = (cfg.costPerOutputToken ?? cfg.costPerToken) || 0;
+        const costPerToken = costIn + costOut;
         const cost = tokens * costPerToken;
         const throughput = latency > 0 ? (tokens * 1000) / latency : 0;
         results[name] = { latency, throughput, cost, costPerToken };

--- a/src/config.js
+++ b/src/config.js
@@ -17,6 +17,7 @@ const defaultCfg = {
   qualityVerify: false,
   useWasmEngine: true,
   autoOpenAfterSave: true,
+  selectionPopup: false,
   theme: 'dark',
   charLimit: 0,
   strategy: 'balanced',
@@ -52,7 +53,14 @@ function migrate(cfg = {}) {
     if (p.charLimit == null) p.charLimit = /^google$|^deepl/.test(id) ? 500000 : out.charLimit || 0;
     if (p.requestLimit == null) p.requestLimit = out.requestLimit;
     if (p.tokenLimit == null) p.tokenLimit = out.tokenLimit;
-    if (p.costPerToken == null) p.costPerToken = 0;
+    if (p.costPerInputToken == null) {
+      if (p.costPerToken != null) p.costPerInputToken = p.costPerToken;
+      else p.costPerInputToken = 0;
+    }
+    if (p.costPerOutputToken == null) {
+      if (p.costPerToken != null) p.costPerOutputToken = p.costPerToken;
+      else p.costPerOutputToken = 0;
+    }
     if (p.weight == null) p.weight = 0;
     if (p.strategy != null) p.strategy = mapStrategy(p.strategy);
     if (p.strategy == null) p.strategy = mapStrategy(out.strategy || 'balanced');
@@ -76,6 +84,7 @@ function migrate(cfg = {}) {
   if (typeof out.failover !== 'boolean') out.failover = true;
   if (typeof out.parallel !== 'boolean' && out.parallel !== 'auto') out.parallel = 'auto';
   if (typeof out.tmSync !== 'boolean') out.tmSync = false;
+  if (typeof out.selectionPopup !== 'boolean') out.selectionPopup = false;
   return out;
 }
 
@@ -116,7 +125,8 @@ function qwenSaveConfig(cfg) {
       tokenLimit: num(cfg.tokenLimit),
       charLimit: num(cfg.charLimit),
       strategy: cfg.strategy,
-      costPerToken: num(cfg.costPerToken),
+      costPerInputToken: num(cfg.costPerInputToken),
+      costPerOutputToken: num(cfg.costPerOutputToken),
       weight: num(cfg.weight),
     };
     const toSave = { ...cfg, providers };

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -283,10 +283,12 @@ async function showSelectionBubble(range, text) {
   result.className = 'qwen-bubble__result';
   result.setAttribute('role', 'status');
   result.setAttribute('aria-live', 'polite');
-  result.textContent = t('bubble.translating');
   selectionBubble.appendChild(result);
   const actions = document.createElement('div');
   actions.className = 'qwen-bubble__actions';
+  const translateBtn = document.createElement('button');
+  translateBtn.textContent = t('bubble.translate');
+  translateBtn.setAttribute('aria-label', t('bubble.translate'));
   const pinBtn = document.createElement('button');
   pinBtn.textContent = t('bubble.pin');
   pinBtn.setAttribute('aria-label', t('bubble.pin'));
@@ -296,8 +298,29 @@ async function showSelectionBubble(range, text) {
   const panelBtn = document.createElement('button');
   panelBtn.textContent = t('bubble.panel');
   panelBtn.setAttribute('aria-label', t('bubble.panel'));
-  actions.append(pinBtn, copyBtn, panelBtn);
+  actions.append(translateBtn, pinBtn, copyBtn, panelBtn);
   selectionBubble.appendChild(actions);
+  translateBtn.addEventListener('click', async () => {
+    result.textContent = t('bubble.translating');
+    const cfg = currentConfig || (await window.qwenLoadConfig());
+    await loadGlossary();
+    try {
+      const res = await window.qwenTranslate({
+        endpoint: cfg.apiEndpoint,
+        model: cfg.model,
+        text,
+        source: cfg.sourceLanguage,
+        target: cfg.targetLanguage,
+        providerOrder: cfg.providerOrder,
+        endpoints: cfg.endpoints,
+        failover: cfg.failover,
+        debug: cfg.debug,
+      });
+      result.textContent = res.text;
+    } catch {
+      result.textContent = 'Translation failed';
+    }
+  });
   pinBtn.addEventListener('click', () => {
     selectionPinned = !selectionPinned;
     pinBtn.classList.toggle('active', selectionPinned);
@@ -313,24 +336,6 @@ async function showSelectionBubble(range, text) {
   selectionBubble.style.left = `${window.scrollX + rect.left}px`;
   document.body.appendChild(selectionBubble);
   selectionBubble.focus();
-  const cfg = currentConfig || (await window.qwenLoadConfig());
-  await loadGlossary();
-  try {
-    const res = await window.qwenTranslate({
-      endpoint: cfg.apiEndpoint,
-      model: cfg.model,
-      text,
-      source: cfg.sourceLanguage,
-      target: cfg.targetLanguage,
-      providerOrder: cfg.providerOrder,
-      endpoints: cfg.endpoints,
-      failover: cfg.failover,
-      debug: cfg.debug,
-    });
-    result.textContent = res.text;
-  } catch {
-    result.textContent = 'Translation failed';
-  }
 }
 
 function handleSelection() {
@@ -645,30 +650,35 @@ async function start() {
   }
   if (currentConfig.debug) logger.debug('QTDEBUG: starting automatic translation');
   setStatus('Scanning page...');
+  scanDocument();
+}
+
+async function scanDocument() {
   const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
   const chunk = [];
   const chunkSize = 200;
   let node;
-  while ((node = walker.nextNode())) {
+  let processed = 0;
+  while (started && (node = walker.nextNode())) {
     if (node.textContent.trim() && shouldTranslate(node)) {
       chunk.push(node);
       if (chunk.length >= chunkSize) {
         prefetchNodes(chunk.splice(0));
       }
     }
+    processed++;
+    if (processed % 500 === 0) {
+      await new Promise(r => setTimeout(r, 0));
+      if (!started) return;
+    }
   }
-  if (chunk.length) prefetchNodes(chunk);
+  if (started && chunk.length) prefetchNodes(chunk);
+  if (!started) return;
   observe();
   if (!batchQueue.length) clearStatus();
 }
 
 if (!skipInit) {
-document.addEventListener('mouseup', handleSelection);
-document.addEventListener('keyup', handleSelection);
-document.addEventListener('mousedown', e => {
-  if (selectionBubble && !selectionBubble.contains(e.target) && !selectionPinned) removeSelectionBubble();
-});
-document.addEventListener('keydown', e => { if (e.key === 'Escape') removeSelectionBubble(); });
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.action === 'start') {
     if (currentConfig && currentConfig.debug) logger.debug('QTDEBUG: start message received');
@@ -766,13 +776,26 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   }
 });
 
-if (document.readyState === 'complete' || document.readyState === 'interactive') {
-  window.qwenLoadConfig().then(cfg => { if (cfg.autoTranslate) start(); });
-} else {
-  window.addEventListener('DOMContentLoaded', () => {
-    window.qwenLoadConfig().then(cfg => { if (cfg.autoTranslate) start(); });
-  });
-}
+  function initConfig() {
+    window.qwenLoadConfig().then(cfg => {
+      currentConfig = cfg;
+      if (cfg.selectionPopup) {
+        document.addEventListener('mouseup', handleSelection);
+        document.addEventListener('keyup', handleSelection);
+        document.addEventListener('mousedown', e => {
+          if (selectionBubble && !selectionBubble.contains(e.target) && !selectionPinned) removeSelectionBubble();
+        });
+        document.addEventListener('keydown', e => { if (e.key === 'Escape') removeSelectionBubble(); });
+      }
+      if (cfg.autoTranslate) start();
+    });
+  }
+
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    initConfig();
+  } else {
+    window.addEventListener('DOMContentLoaded', initConfig);
+  }
 }
 
 if (typeof module !== 'undefined') {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -6,6 +6,7 @@
   "popup.ariaMain": "Translator settings",
   "panel.ariaLabel": "Translations",
   "bubble.translating": "Translating...",
+  "bubble.translate": "Translate",
   "bubble.pin": "Pin",
   "bubble.copy": "Copy",
   "bubble.panel": "Panel",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -6,6 +6,7 @@
   "popup.ariaMain": "翻译器设置",
   "panel.ariaLabel": "翻译",
   "bubble.translating": "翻译中...",
+  "bubble.translate": "翻译",
   "bubble.pin": "固定",
   "bubble.copy": "复制",
   "bubble.panel": "面板",

--- a/src/popup.js
+++ b/src/popup.js
@@ -25,6 +25,12 @@
       case 'home:auto-translate':
         chrome.storage?.sync?.set({ autoTranslate: msg.enabled });
         chrome.runtime.sendMessage({ action: 'set-config', config: { autoTranslate: msg.enabled } });
+        if (!msg.enabled) {
+          chrome.tabs?.query?.({ active: true, currentWindow: true }, tabs => {
+            const t = tabs && tabs[0];
+            if (t) chrome.tabs.sendMessage(t.id, { action: 'stop' });
+          });
+        }
         break;
       case 'home:init':
         Promise.all([

--- a/src/popup/home.html
+++ b/src/popup/home.html
@@ -36,7 +36,7 @@
   </style>
 </head>
 <body>
-  <button id="quickTranslate" class="primary">Quick translate</button>
+  <button id="quickTranslate" class="primary">Translate page</button>
   <div class="lang-select">
     <select id="srcLang"></select>
     <span>→</span>

--- a/src/popup/providerEditor.html
+++ b/src/popup/providerEditor.html
@@ -9,8 +9,9 @@
       <label data-field="tokenLimit">Tokens/min <input id="pe_tokenLimit" type="number" min="0"></label>
       <label data-field="charLimit">Chars/month <input id="pe_charLimit" type="number" min="0"></label>
       <label data-field="strategy">Strategy <input id="pe_strategy"></label>
-      <label data-field="costPerToken">Cost/token <input id="pe_costPerToken" type="number" step="0.0001" min="0"></label>
-      <label data-field="weight">Weight <input id="pe_weight" type="number" step="0.01" min="0"></label>
+      <label data-field="costPerInputToken" title="Cost per million input tokens in USD">Input cost per 1M tokens (USD) <input id="pe_costPerInputToken" type="number" step="0.01" min="0"></label>
+      <label data-field="costPerOutputToken" title="Cost per million output tokens in USD">Output cost per 1M tokens (USD) <input id="pe_costPerOutputToken" type="number" step="0.01" min="0"></label>
+      <label data-field="weight" title="Relative load-balancing preference when multiple providers are available">Weight <input id="pe_weight" type="number" step="0.01" min="0"></label>
     </details>
     <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-top:0.5rem;">
       <button id="pe_save">Save</button>

--- a/src/popup/providerEditor.js
+++ b/src/popup/providerEditor.js
@@ -8,7 +8,8 @@
   const tokLimitEl = overlay.querySelector('#pe_tokenLimit');
   const charLimitEl = overlay.querySelector('#pe_charLimit');
   const strategyEl = overlay.querySelector('#pe_strategy');
-  const costPerTokenEl = overlay.querySelector('#pe_costPerToken');
+  const costPerInputTokenEl = overlay.querySelector('#pe_costPerInputToken');
+  const costPerOutputTokenEl = overlay.querySelector('#pe_costPerOutputToken');
   const weightEl = overlay.querySelector('#pe_weight');
   const saveBtn = overlay.querySelector('#pe_save');
   const cancelBtn = overlay.querySelector('#pe_cancel');
@@ -31,7 +32,10 @@
     tokLimitEl.value = existing.tokenLimit ?? cfg.tokenLimit ?? '';
     charLimitEl.value = existing.charLimit ?? cfg.charLimit ?? '';
     strategyEl.value = existing.strategy || cfg.strategy || '';
-    costPerTokenEl.value = existing.costPerToken ?? cfg.costPerToken ?? '';
+    const cpi = existing.costPerInputToken ?? cfg.costPerInputToken ?? existing.costPerToken ?? cfg.costPerToken;
+    const cpo = existing.costPerOutputToken ?? cfg.costPerOutputToken ?? existing.costPerToken ?? cfg.costPerToken;
+    costPerInputTokenEl.value = cpi != null ? cpi * 1e6 : '';
+    costPerOutputTokenEl.value = cpo != null ? cpo * 1e6 : '';
     weightEl.value = existing.weight ?? cfg.weight ?? '';
     modelList.innerHTML = '';
     const prov = window.qwenProviders?.getProvider?.(id);
@@ -58,6 +62,8 @@
     apiEndpointEl.classList.remove('invalid');
     const providers = cfg.providers || {};
     const num = v => (v === '' ? undefined : Number(v));
+    const costInRaw = num(costPerInputTokenEl.value.trim());
+    const costOutRaw = num(costPerOutputTokenEl.value.trim());
     providers[currentId] = {
       ...(providers[currentId] || {}),
       apiKey: apiKeyEl.value.trim(),
@@ -67,7 +73,8 @@
       tokenLimit: num(tokLimitEl.value.trim()),
       charLimit: num(charLimitEl.value.trim()),
       strategy: strategyEl.value.trim(),
-      costPerToken: num(costPerTokenEl.value.trim()),
+      costPerInputToken: costInRaw == null ? undefined : costInRaw / 1e6,
+      costPerOutputToken: costOutRaw == null ? undefined : costOutRaw / 1e6,
       weight: num(weightEl.value.trim()),
     };
     cfg.providers = providers;

--- a/src/popup/settings.html
+++ b/src/popup/settings.html
@@ -51,6 +51,12 @@
       <p class="note">One entry per line, using "term=translation".</p>
     </section>
 
+    <section id="selectionSection">
+      <h3>Selection Translation</h3>
+      <label><input type="checkbox" id="selectionPopup"> Show bubble on text selection</label>
+      <p class="note">Bubble waits for you to trigger translation.</p>
+    </section>
+
     <section id="panelSection">
       <h3>Conversation Panel</h3>
       <button id="openPanel">Open panel</button>

--- a/src/popup/settings.js
+++ b/src/popup/settings.js
@@ -5,6 +5,7 @@
     glossary: '',
     cacheEnabled: false,
     localProviders: [],
+    selectionPopup: false,
   };
 
   const store = await new Promise(res => {
@@ -44,6 +45,14 @@
   detectBox.addEventListener('change', () => {
     chrome?.storage?.sync?.set({ enableDetection: detectBox.checked });
   });
+
+  const selectionBox = document.getElementById('selectionPopup');
+  if (selectionBox) {
+    selectionBox.checked = store.selectionPopup;
+    selectionBox.addEventListener('change', () => {
+      chrome?.storage?.sync?.set({ selectionPopup: selectionBox.checked });
+    });
+  }
 
   const glossaryField = document.getElementById('glossary');
   glossaryField.value = store.glossary;

--- a/src/providerConfig.js
+++ b/src/providerConfig.js
@@ -4,7 +4,8 @@ function applyProviderConfig(provider, doc = document) {
     'tokenLimit',
     'charLimit',
     'strategy',
-    'costPerToken',
+    'costPerInputToken',
+    'costPerOutputToken',
     'weight',
   ];
   const fields = ((provider && provider.configFields) || ['apiKey', 'apiEndpoint', 'model']).concat(advanced);
@@ -41,7 +42,8 @@ function loadProviderConfig() {
     tokenLimit: undefined,
     charLimit: undefined,
     strategy: undefined,
-    costPerToken: undefined,
+    costPerInputToken: undefined,
+    costPerOutputToken: undefined,
     weight: undefined,
   };
   if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.sync) {
@@ -73,7 +75,8 @@ function saveProviderConfig(cfg) {
       tokenLimit: primary.tokenLimit,
       charLimit: primary.charLimit,
       strategy: primary.strategy,
-      costPerToken: primary.costPerToken,
+      costPerInputToken: primary.costPerInputToken,
+      costPerOutputToken: primary.costPerOutputToken,
       weight: primary.weight,
     };
     return new Promise(resolve => chrome.storage.sync.set(toSave, resolve));

--- a/src/translator.js
+++ b/src/translator.js
@@ -725,7 +725,9 @@ async function batchOnce({
       const impl = Providers && Providers.get ? Providers.get(id) : null;
       const usage = t && t.getUsage ? t.getUsage() : {};
       tokLim = usage.tokenLimit || (impl && impl.throttle && impl.throttle.tokenLimit) || 0;
-      const cost = impl && impl.costPerToken != null ? impl.costPerToken : 1;
+      const costIn = impl && impl.costPerInputToken != null ? impl.costPerInputToken : impl && impl.costPerToken != null ? impl.costPerToken : 1;
+      const costOut = impl && impl.costPerOutputToken != null ? impl.costPerOutputToken : impl && impl.costPerToken != null ? impl.costPerToken : 0;
+      const cost = costIn + costOut;
       w = impl && impl.weight != null ? impl.weight : (cost > 0 ? (tokLim || 0) / cost : tokLim || 1);
     } catch {}
     if (!Number.isFinite(w) || w <= 0) w = 1;

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -43,4 +43,12 @@ describe('config migration', () => {
     expect(cfg.providers.google.charLimit).toBe(500000);
     expect(cfg.providers.deepl.charLimit).toBe(500000);
   });
+
+  test('selection popup disabled by default', async () => {
+    const set = jest.fn((o, cb) => cb && cb());
+    global.chrome = { storage: { sync: { get: (d, cb) => cb(d), set } } };
+    const { qwenLoadConfig } = require('../src/config.js');
+    const cfg = await qwenLoadConfig();
+    expect(cfg.selectionPopup).toBe(false);
+  });
 });

--- a/test/contentScript.test.js
+++ b/test/contentScript.test.js
@@ -12,7 +12,7 @@ window.qwenTranslateBatch = async ({ texts, onProgress }) => {
   if (onProgress) onProgress({ phase: 'translate', request: 1, requests: 2, sample: texts[0] });
   return { texts: texts.map(t => `X${t}X`) };
 };
-window.qwenLoadConfig = async () => ({ apiKey: 'k', apiEndpoint: 'https://e/', model: 'm', sourceLanguage: 'nl', targetLanguage: 'en', debug: false });
+window.qwenLoadConfig = async () => ({ apiKey: 'k', apiEndpoint: 'https://e/', model: 'm', sourceLanguage: 'nl', targetLanguage: 'en', debug: false, selectionPopup: true });
 window.getComputedStyle = () => ({ visibility: 'visible', display: 'block' });
 Element.prototype.getClientRects = () => [1];
 
@@ -219,6 +219,8 @@ test('shows bubble on text selection and translates', async () => {
   sel.addRange(range);
   document.dispatchEvent(new MouseEvent('mouseup'));
   await new Promise(r => setTimeout(r, 0));
+  await new Promise(r => setTimeout(r, 0));
+  document.querySelector('.qwen-bubble__actions button').click();
   await new Promise(r => setTimeout(r, 0));
   const bubble = document.querySelector('.qwen-bubble__result');
   expect(spy).toHaveBeenCalledWith(expect.objectContaining({ text: 'Hello' }));

--- a/test/popup.test.js
+++ b/test/popup.test.js
@@ -20,6 +20,10 @@ describe('popup shell routing', () => {
           get: jest.fn((defaults, cb) => cb(defaults)),
         },
       },
+      tabs: {
+        query: jest.fn((opts, cb) => cb([{ id: 1 }])),
+        sendMessage: jest.fn(),
+      },
     };
     global.window.qwenProviderConfig = {
       loadProviderConfig: jest.fn(() => Promise.resolve({ providerOrder: ['qwen'], provider: 'qwen', providers: {} })),
@@ -46,6 +50,12 @@ describe('popup shell routing', () => {
     listener({ action: 'home:auto-translate', enabled: true });
     expect(chrome.storage.sync.set).toHaveBeenCalledWith({ autoTranslate: true });
     expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'set-config', config: { autoTranslate: true } });
+
+    listener({ action: 'home:auto-translate', enabled: false });
+    expect(chrome.storage.sync.set).toHaveBeenCalledWith({ autoTranslate: false });
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'set-config', config: { autoTranslate: false } });
+    expect(chrome.tabs.query).toHaveBeenCalledWith({ active: true, currentWindow: true }, expect.any(Function));
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(1, { action: 'stop' });
   });
 
   test('initializes home view via home:init', async () => {

--- a/test/translator.parallel.test.js
+++ b/test/translator.parallel.test.js
@@ -8,8 +8,8 @@ describe('translator parallel mode', () => {
   test('distributes batches by provider weight', async () => {
     const Providers = require('../src/lib/providers.js');
     Providers.reset();
-    const a = { translate: jest.fn(async ({ text }) => ({ text: `A:${text}` })), throttle: { tokenLimit: 100 }, costPerToken: 1 };
-    const b = { translate: jest.fn(async ({ text }) => ({ text: `B:${text}` })), throttle: { tokenLimit: 100 }, costPerToken: 2 };
+    const a = { translate: jest.fn(async ({ text }) => ({ text: `A:${text}` })), throttle: { tokenLimit: 100 }, costPerInputToken: 1 };
+    const b = { translate: jest.fn(async ({ text }) => ({ text: `B:${text}` })), throttle: { tokenLimit: 100 }, costPerInputToken: 2 };
     Providers.register('a', a);
     Providers.register('b', b);
     Providers.init();
@@ -33,8 +33,8 @@ describe('translator parallel mode', () => {
   test('falls back when provider quota exhausted', async () => {
     const Providers = require('../src/lib/providers.js');
     Providers.reset();
-    const a = { translate: jest.fn(async ({ text }) => ({ text: `A:${text}` })), throttle: { tokenLimit: 4 }, costPerToken: 1 };
-    const b = { translate: jest.fn(async ({ text }) => ({ text: `B:${text}` })), throttle: { tokenLimit: 100 }, costPerToken: 25 };
+    const a = { translate: jest.fn(async ({ text }) => ({ text: `A:${text}` })), throttle: { tokenLimit: 4 }, costPerInputToken: 1 };
+    const b = { translate: jest.fn(async ({ text }) => ({ text: `B:${text}` })), throttle: { tokenLimit: 100 }, costPerInputToken: 25 };
     Providers.register('a', a);
     Providers.register('b', b);
     Providers.init();


### PR DESCRIPTION
## Summary
- allow configuring distinct costs for input and output tokens
- compute provider weights and benchmarks using combined token costs
- add optional selection bubble with manual translate button
- rename quick translate to Translate page and improve auto-translate responsiveness
- bump version to 1.27.0

## Testing
- `npm test --silent`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a1ed27691c8323a7aef6eb200adc68