### PR TITLE
feat: open conversation panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.23.2",
+  "version": "1.24.0",
   "version_name": "2025-08-20",
   "update_url": "https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/updates.xml",
   "permissions": [

--- a/src/popup/settings.js
+++ b/src/popup/settings.js
@@ -54,6 +54,11 @@
     });
   }
 
+  const panelBtn = document.getElementById('openPanel');
+  panelBtn?.addEventListener('click', () => {
+    chrome?.windows?.create({ url: 'panel/panel.html', type: 'popup' });
+  });
+
   const glossaryField = document.getElementById('glossary');
   glossaryField.value = store.glossary;
   glossaryField.addEventListener('input', () => {

--- a/updates.xml
+++ b/updates.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gupdate xmlns="http://www.google.com/update2/response" protocol="2.0">
   <app appid="YOUR_EXTENSION_ID">
-    <updatecheck codebase="https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/qwen-translator-extension.crx" version="1.23.2" />
+    <updatecheck codebase="https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/qwen-translator-extension.crx" version="1.24.0" />
   </app>
 </gupdate>


### PR DESCRIPTION
## Summary
- open conversation panel from the settings page
- bump extension version to 1.24.0 / 1.28.0

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a207357a348323b70665d436a01367