### PR TITLE
Defer popup scripts and load diagnostics chart on demand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.27.1",
+  "version": "1.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.27.1",
+      "version": "1.28.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "version_name": "2025-08-20",
   "update_url": "https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/updates.xml",
   "permissions": [

--- a/src/popup/diagnostics.html
+++ b/src/popup/diagnostics.html
@@ -21,7 +21,6 @@
   <ul id="providers"></ul>
   <button id="back" class="secondary">Back</button>
   <button id="copy" class="primary">Copy Report</button>
-  <script src="../qa/chart.umd.js"></script>
   <script src="diagnostics.js"></script>
 </body>
 </html>

--- a/src/popup/diagnostics.js
+++ b/src/popup/diagnostics.js
@@ -5,8 +5,19 @@
   const backBtn = document.getElementById('back');
   const summaryEl = document.getElementById('usageSummary');
   const chartEl = document.getElementById('usageChart');
+  let Chart;
+  if (chartEl) {
+    await new Promise((resolve, reject) => {
+      if (window.Chart) { Chart = window.Chart; return resolve(); }
+      const s = document.createElement('script');
+      s.src = '../qa/chart.umd.js';
+      s.onload = () => { Chart = window.Chart; resolve(); };
+      s.onerror = reject;
+      document.head.appendChild(s);
+    });
+  }
   const ctx = chartEl && chartEl.getContext('2d');
-  const chart = ctx && new Chart(ctx, {
+  const chart = Chart && ctx && new Chart(ctx, {
     type: 'line',
     data: {
       labels: [],

--- a/src/popup/home.html
+++ b/src/popup/home.html
@@ -50,8 +50,18 @@
   <div id="limits" class="stats"></div>
   <div id="cacheStatus" class="stats"></div>
   <button id="toDiagnostics" class="secondary">Diagnostics</button>
-  <script src="../languages.js"></script>
   <script src="../usageColor.js"></script>
-  <script src="home.js"></script>
+  <script>
+    window.addEventListener('DOMContentLoaded', () => {
+      const load = src => new Promise((resolve, reject) => {
+        const s = document.createElement('script');
+        s.src = src;
+        s.onload = resolve;
+        s.onerror = reject;
+        document.head.appendChild(s);
+      });
+      load('../languages.js').then(() => load('home.js'));
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Defer popup's language and logic scripts until after DOM ready
- Load diagnostics Chart bundle only when diagnostics page runs
- Bump version to 1.28.1

## Testing
- `npm test`
- `node - <<'NODE'
const { chromium } = require('playwright');
(async () => {
  const browser = await chromium.launch();
  const page = await browser.newPage();
  await page.goto('file://' + process.cwd() + '/src/popup/home.html');
  const timing = await page.evaluate(() => {
    const nav = performance.getEntriesByType('navigation')[0];
    return { domContentLoaded: nav.domContentLoadedEventEnd, load: nav.loadEventEnd };
  });
  console.log('DOMContentLoaded:', timing.domContentLoaded.toFixed(2));
  console.log('Load:', timing.load.toFixed(2));
  await browser.close();
})();
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a209cba6e4832389b3f1bf86e8cef2