### PR TITLE
Display provider key availability in popup home view

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -44,7 +44,8 @@
           const usage = metrics && metrics.usage ? metrics.usage : {};
           const cache = metrics && metrics.cache ? metrics.cache : {};
           const tm = metrics && metrics.tm ? metrics.tm : {};
-          sendResponse({ provider, usage, cache, tm, auto: autoCfg.autoTranslate });
+          const apiKey = !!(metrics && metrics.providers && metrics.providers[provider] && metrics.providers[provider].apiKey);
+          sendResponse({ provider, apiKey, usage, cache, tm, auto: autoCfg.autoTranslate });
         });
         return true;
       case 'home:get-usage':

--- a/src/popup/home.html
+++ b/src/popup/home.html
@@ -33,6 +33,9 @@
     .stats {
       font-size: 0.75rem;
     }
+    #providerKey {
+      margin-left: 0.25rem;
+    }
   </style>
 </head>
 <body>
@@ -43,7 +46,7 @@
     <select id="destLang"></select>
   </div>
   <label class="auto-toggle"><input type="checkbox" id="autoTranslate"> Auto-translate</label>
-  <div id="provider">Provider: <span id="providerName">-</span></div>
+  <div id="provider">Provider: <span id="providerName">-</span> <span id="providerKey"></span></div>
   <div id="usage" class="stats">Requests: 0/0 Tokens: 0/0</div>
   <progress id="reqBar" value="0" max="0"></progress>
   <progress id="tokBar" value="0" max="0"></progress>

--- a/src/popup/home.js
+++ b/src/popup/home.js
@@ -2,6 +2,7 @@
   const quickBtn = document.getElementById('quickTranslate');
   const autoToggle = document.getElementById('autoTranslate');
   const providerName = document.getElementById('providerName');
+  const providerKey = document.getElementById('providerKey');
   const usageEl = document.getElementById('usage');
   const limitsEl = document.getElementById('limits');
   const cacheEl = document.getElementById('cacheStatus');
@@ -57,6 +58,7 @@
   chrome.runtime.sendMessage({ action: 'home:init' }, res => {
     if (!res) return;
     providerName.textContent = res.provider || '-';
+    if (providerKey) providerKey.textContent = res.apiKey ? '✓' : '✗';
     const u = res.usage || {};
     usageEl.textContent = `Requests: ${u.requests || 0}/${u.requestLimit || 0} Tokens: ${u.tokens || 0}/${u.tokenLimit || 0}`;
     if (limitsEl) limitsEl.textContent = `Queue: ${u.queue || 0}`;

--- a/test/popup.test.js
+++ b/test/popup.test.js
@@ -59,15 +59,15 @@ describe('popup shell routing', () => {
   });
 
   test('initializes home view via home:init', async () => {
-    chrome.runtime.sendMessage.mockImplementation((msg, cb) => {
-      if (msg.action === 'metrics') cb({ usage: { requests: 1, tokens: 2 }, cache: {}, tm: {} });
-    });
+      chrome.runtime.sendMessage.mockImplementation((msg, cb) => {
+        if (msg.action === 'metrics') cb({ usage: { requests: 1, tokens: 2 }, cache: {}, tm: {}, providers: { qwen: { apiKey: true } } });
+      });
     require('../src/popup.js');
     await new Promise(resolve => {
-    const ret = listener({ action: 'home:init' }, {}, res => {
-      expect(res).toEqual({ provider: 'qwen', usage: { requests: 1, tokens: 2 }, cache: {}, tm: {}, auto: false });
-      resolve();
-    });
+      const ret = listener({ action: 'home:init' }, {}, res => {
+        expect(res).toEqual({ provider: 'qwen', apiKey: true, usage: { requests: 1, tokens: 2 }, cache: {}, tm: {}, auto: false });
+        resolve();
+      });
       expect(ret).toBe(true);
     });
     expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'metrics' }, expect.any(Function));

--- a/test/popupCache.test.js
+++ b/test/popupCache.test.js
@@ -7,7 +7,7 @@ describe('home usage updates', () => {
     document.body.innerHTML = `
       <button id="quickTranslate"></button>
       <label><input type="checkbox" id="autoTranslate"></label>
-      <div id="provider">Provider: <span id="providerName"></span></div>
+        <div id="provider">Provider: <span id="providerName"></span> <span id="providerKey"></span></div>
       <div id="usage">Requests: 0/0 Tokens: 0/0</div>
       <progress id="reqBar" value="0" max="0"></progress>
       <progress id="tokBar" value="0" max="0"></progress>
@@ -19,7 +19,7 @@ describe('home usage updates', () => {
     global.chrome = {
       runtime: {
         sendMessage: jest.fn((msg, cb) => {
-          if (msg.action === 'home:init') cb({ provider: 'p', usage: { requests: 1, tokens: 2, requestLimit: 10, tokenLimit: 20, queue: 0 }, cache: {}, tm: {}, auto: false });
+        if (msg.action === 'home:init') cb({ provider: 'p', apiKey: true, usage: { requests: 1, tokens: 2, requestLimit: 10, tokenLimit: 20, queue: 0 }, cache: {}, tm: {}, auto: false });
         }),
         onMessage: { addListener: fn => { listener = fn; } },
       },
@@ -36,7 +36,8 @@ describe('home usage updates', () => {
   });
 
   test('updates usage on runtime message', () => {
-    expect(document.getElementById('usage').textContent).toBe('Requests: 1/10 Tokens: 2/20');
+      expect(document.getElementById('usage').textContent).toBe('Requests: 1/10 Tokens: 2/20');
+      expect(document.getElementById('providerKey').textContent).toBe('✓');
     expect(document.getElementById('reqBar').value).toBe(1);
     expect(document.getElementById('reqBar').max).toBe(10);
     listener({ action: 'home:update-usage', usage: { requests: 3, tokens: 4, requestLimit: 10, tokenLimit: 20, queue: 1 } });

--- a/test/popupCost.test.js
+++ b/test/popupCost.test.js
@@ -6,7 +6,7 @@ describe('home view display', () => {
     document.body.innerHTML = `
       <button id="quickTranslate"></button>
       <label><input type="checkbox" id="autoTranslate"></label>
-      <div id="provider">Provider: <span id="providerName"></span></div>
+        <div id="provider">Provider: <span id="providerName"></span> <span id="providerKey"></span></div>
       <div id="usage">Requests: 0/0 Tokens: 0/0</div>
       <progress id="reqBar" value="0" max="0"></progress>
       <progress id="tokBar" value="0" max="0"></progress>
@@ -32,17 +32,19 @@ describe('home view display', () => {
 
   test('initializes and handles actions', () => {
     chrome.runtime.sendMessage.mockImplementation((msg, cb) => {
-      if (msg.action === 'home:init') cb({
-        provider: 'qwen',
-        usage: { requests: 5, tokens: 10, requestLimit: 100, tokenLimit: 200, queue: 0 },
-        cache: { size: 1, max: 2 },
-        tm: { hits: 3, misses: 4 },
-        auto: false,
-      });
+        if (msg.action === 'home:init') cb({
+          provider: 'qwen',
+          apiKey: false,
+          usage: { requests: 5, tokens: 10, requestLimit: 100, tokenLimit: 200, queue: 0 },
+          cache: { size: 1, max: 2 },
+          tm: { hits: 3, misses: 4 },
+          auto: false,
+        });
     });
     require('../src/popup/home.js');
     expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'home:init' }, expect.any(Function));
-    expect(document.getElementById('providerName').textContent).toBe('qwen');
+      expect(document.getElementById('providerName').textContent).toBe('qwen');
+      expect(document.getElementById('providerKey').textContent).toBe('✗');
     expect(document.getElementById('usage').textContent).toBe('Requests: 5/100 Tokens: 10/200');
     expect(document.getElementById('reqBar').value).toBe(5);
     expect(document.getElementById('reqBar').max).toBe(100);


### PR DESCRIPTION
## Summary
- return API key presence from `home:init`
- show check or cross next to provider name in popup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20c33f6ac8323a84b96862edce0f7