### PR TITLE
refactor: extract popup init script

### DIFF
--- a/src/popup/home.html
+++ b/src/popup/home.html
@@ -54,17 +54,8 @@
   <div id="cacheStatus" class="stats"></div>
   <button id="toDiagnostics" class="secondary">Diagnostics</button>
   <script src="../usageColor.js"></script>
-  <script>
-    window.addEventListener('DOMContentLoaded', () => {
-      const load = src => new Promise((resolve, reject) => {
-        const s = document.createElement('script');
-        s.src = src;
-        s.onload = resolve;
-        s.onerror = reject;
-        document.head.appendChild(s);
-      });
-      load('../languages.js').then(() => load('home.js'));
-    });
-  </script>
+  <script src="../languages.js" defer></script>
+  <script src="home.js" defer></script>
+  <script src="init.js" defer></script>
 </body>
 </html>

--- a/src/popup/init.js
+++ b/src/popup/init.js
@@ -1,0 +1,10 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const load = src => new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = src;
+    s.onload = resolve;
+    s.onerror = reject;
+    document.head.appendChild(s);
+  });
+  load('../languages.js').then(() => load('home.js'));
+});


### PR DESCRIPTION
## Summary
- move DOMContentLoaded loader into new `popup/init.js`
- load `languages.js`, `home.js`, and `init.js` via external scripts in `popup/home.html`

## Testing
- `npm test 2>&1 | tail -n 15`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a21347e1b48323b5f91723aca7bb56