### PR TITLE
Expose providers globally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.28.2",
+  "version": "1.28.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.28.2",
+    "version": "1.28.3",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.28.2",
+  "version": "1.28.3",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/providers/anthropic.js
+++ b/src/providers/anthropic.js
@@ -1,7 +1,8 @@
 (function (root, factory) {
-  const mod = factory(root);
-  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
-  else root.qwenProviderAnthropic = mod;
+  const provider = factory(root);
+  if (typeof window !== 'undefined') window.qwenProviderAnthropic = provider;
+  else if (typeof self !== 'undefined') self.qwenProviderAnthropic = provider;
+  if (typeof module !== 'undefined') module.exports = provider;
 }(typeof self !== 'undefined' ? self : this, function (root) {
   const logger = (root.qwenLogger && root.qwenLogger.create) ? root.qwenLogger.create('provider:anthropic') : console;
   const fetchFn = (typeof fetch !== 'undefined') ? fetch : (root.fetch || null);

--- a/src/providers/dashscope.js
+++ b/src/providers/dashscope.js
@@ -1,7 +1,8 @@
 (function (root, factory) {
-  const mod = factory(root);
-  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
-  else root.qwenProviderDashScope = mod;
+  const provider = factory(root);
+  if (typeof window !== 'undefined') window.qwenProviderDashScope = provider;
+  else if (typeof self !== 'undefined') self.qwenProviderDashScope = provider;
+  if (typeof module !== 'undefined') module.exports = provider;
 }(typeof self !== 'undefined' ? self : this, function (root) {
   const logger = (root.qwenLogger && root.qwenLogger.create) ? root.qwenLogger.create('provider:dashscope') : console;
   const fetchFn = (typeof fetch !== 'undefined') ? fetch : (root.fetch || null);

--- a/src/providers/deepl.js
+++ b/src/providers/deepl.js
@@ -1,7 +1,8 @@
 (function (root, factory) {
-  const mod = factory(root);
-  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
-  else root.qwenProviderDeepL = mod;
+  const provider = factory(root);
+  if (typeof window !== 'undefined') window.qwenProviderDeepL = provider;
+  else if (typeof self !== 'undefined') self.qwenProviderDeepL = provider;
+  if (typeof module !== 'undefined') module.exports = provider;
 }(typeof self !== 'undefined' ? self : this, function (root) {
   const fetchFn = (typeof fetch !== 'undefined') ? fetch : (root.fetch || null);
     function withSlash(u) { return /\/$/.test(u) ? u : u + '/'; }
@@ -58,7 +59,15 @@
     const basic = makeProvider('https://api-free.deepl.com/');
     const free = makeProvider('https://api-free.deepl.com/');
     const pro = makeProvider('https://api.deepl.com/');
-
-    return { translate, basic, free, pro };
+    const provider = { translate, basic, free, pro };
+    try {
+      const reg = root.qwenProviders || (typeof require !== 'undefined' ? require('../lib/providers') : null);
+      if (reg && reg.register) {
+        if (!reg.get('deepl')) reg.register('deepl', provider.basic);
+        if (!reg.get('deepl-free')) reg.register('deepl-free', provider.free);
+        if (!reg.get('deepl-pro')) reg.register('deepl-pro', provider.pro);
+      }
+    } catch {}
+    return provider;
   }));
 

--- a/src/providers/gemini.js
+++ b/src/providers/gemini.js
@@ -1,7 +1,8 @@
 (function (root, factory) {
-  const mod = factory(root);
-  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
-  else root.qwenProviderGemini = mod;
+  const provider = factory(root);
+  if (typeof window !== 'undefined') window.qwenProviderGemini = provider;
+  else if (typeof self !== 'undefined') self.qwenProviderGemini = provider;
+  if (typeof module !== 'undefined') module.exports = provider;
 }(typeof self !== 'undefined' ? self : this, function (root) {
   const logger = (root.qwenLogger && root.qwenLogger.create) ? root.qwenLogger.create('provider:gemini') : console;
   const fetchFn = (typeof fetch !== 'undefined') ? fetch : (root.fetch || null);

--- a/src/providers/google.js
+++ b/src/providers/google.js
@@ -57,15 +57,14 @@ const provider = {
   label: 'Google',
   configFields: ['apiKey', 'apiEndpoint', 'model'],
 };
+if (typeof window !== 'undefined') window.qwenProviderGoogle = provider;
+else if (typeof self !== 'undefined') self.qwenProviderGoogle = provider;
 
-if (typeof window !== 'undefined' && window.qwenProviders) {
-  const reg = window.qwenProviders;
-  const fn = reg.registerProvider || reg.register;
-  if (fn) fn.call(reg, 'google', provider);
-} else if (typeof self !== 'undefined' && self.qwenProviders) {
-  const reg = self.qwenProviders;
-  const fn = reg.registerProvider || reg.register;
-  if (fn) fn.call(reg, 'google', provider);
-}
+try {
+  const reg = (typeof window !== 'undefined' && window.qwenProviders) ||
+              (typeof self !== 'undefined' && self.qwenProviders) ||
+              (typeof require !== 'undefined' ? require('../lib/providers') : null);
+  if (reg && reg.register && !reg.get('google')) reg.register('google', provider);
+} catch {}
 
-module.exports = provider;
+if (typeof module !== 'undefined') module.exports = provider;

--- a/src/providers/localWasm.js
+++ b/src/providers/localWasm.js
@@ -35,6 +35,8 @@ const provider = {
   configFields: [],
   throttle: { requestLimit: 1, windowMs: 1000 },
 };
+if (typeof window !== 'undefined') window.qwenProviderLocalWasm = provider;
+else if (typeof self !== 'undefined') self.qwenProviderLocalWasm = provider;
 
 try {
   const reg = (typeof window !== 'undefined' && window.qwenProviders) ||
@@ -43,4 +45,4 @@ try {
   if (reg && reg.register && !reg.get('local-wasm')) reg.register('local-wasm', provider);
 } catch {}
 
-module.exports = provider;
+if (typeof module !== 'undefined') module.exports = provider;

--- a/src/providers/macos.js
+++ b/src/providers/macos.js
@@ -1,7 +1,8 @@
 (function (root, factory) {
-  const mod = factory(root);
-  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
-  else root.qwenProviderMacOS = mod;
+  const provider = factory(root);
+  if (typeof window !== 'undefined') window.qwenProviderMacos = provider;
+  else if (typeof self !== 'undefined') self.qwenProviderMacos = provider;
+  if (typeof module !== 'undefined') module.exports = provider;
 }(typeof self !== 'undefined' ? self : this, function (root) {
   async function translate({ text, source, target }) {
     const handler = root && root.webkit && root.webkit.messageHandlers && root.webkit.messageHandlers.translate;

--- a/src/providers/mistral.js
+++ b/src/providers/mistral.js
@@ -1,7 +1,8 @@
 (function (root, factory) {
-  const mod = factory(root);
-  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
-  else root.qwenProviderMistral = mod;
+  const provider = factory(root);
+  if (typeof window !== 'undefined') window.qwenProviderMistral = provider;
+  else if (typeof self !== 'undefined') self.qwenProviderMistral = provider;
+  if (typeof module !== 'undefined') module.exports = provider;
 }(typeof self !== 'undefined' ? self : this, function (root) {
   const logger = (root.qwenLogger && root.qwenLogger.create) ? root.qwenLogger.create('provider:mistral') : console;
   const fetchFn = (typeof fetch !== 'undefined') ? fetch : (root.fetch || null);

--- a/src/providers/ollama.js
+++ b/src/providers/ollama.js
@@ -1,7 +1,8 @@
 (function (root, factory) {
-  const mod = factory(root);
-  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
-  else root.qwenProviderOllama = mod;
+  const provider = factory(root);
+  if (typeof window !== 'undefined') window.qwenProviderOllama = provider;
+  else if (typeof self !== 'undefined') self.qwenProviderOllama = provider;
+  if (typeof module !== 'undefined') module.exports = provider;
 }(typeof self !== 'undefined' ? self : this, function (root) {
   const logger = (root.qwenLogger && root.qwenLogger.create) ? root.qwenLogger.create('provider:ollama') : console;
   const fetchFn = (typeof fetch !== 'undefined') ? fetch : (root.fetch || null);

--- a/src/providers/openai.js
+++ b/src/providers/openai.js
@@ -1,7 +1,8 @@
 (function (root, factory) {
-  const mod = factory(root);
-  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
-  else root.qwenProviderOpenAI = mod;
+  const provider = factory(root);
+  if (typeof window !== 'undefined') window.qwenProviderOpenAI = provider;
+  else if (typeof self !== 'undefined') self.qwenProviderOpenAI = provider;
+  if (typeof module !== 'undefined') module.exports = provider;
 }(typeof self !== 'undefined' ? self : this, function (root) {
   const logger = (root.qwenLogger && root.qwenLogger.create) ? root.qwenLogger.create('provider:openai') : console;
   const fetchFn = (typeof fetch !== 'undefined') ? fetch : (root.fetch || null);

--- a/src/providers/openrouter.js
+++ b/src/providers/openrouter.js
@@ -1,7 +1,8 @@
 (function (root, factory) {
-  const mod = factory(root);
-  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
-  else root.qwenProviderOpenRouter = mod;
+  const provider = factory(root);
+  if (typeof window !== 'undefined') window.qwenProviderOpenRouter = provider;
+  else if (typeof self !== 'undefined') self.qwenProviderOpenRouter = provider;
+  if (typeof module !== 'undefined') module.exports = provider;
 }(typeof self !== 'undefined' ? self : this, function (root) {
   const logger = (root.qwenLogger && root.qwenLogger.create) ? root.qwenLogger.create('provider:openrouter') : console;
   const fetchFn = (typeof fetch !== 'undefined') ? fetch : (root.fetch || null);

--- a/src/providers/qwen.js
+++ b/src/providers/qwen.js
@@ -183,6 +183,8 @@ const provider = {
   configFields: ['apiKey', 'apiEndpoint', 'model', 'secondaryModel', 'secondaryModelWarning'],
   throttle: { requestLimit: 5, windowMs: 1000 },
 };
+if (typeof window !== 'undefined') window.qwenProviderQwen = provider;
+else if (typeof self !== 'undefined') self.qwenProviderQwen = provider;
 
 try {
   const reg = (typeof window !== 'undefined' && window.qwenProviders) ||
@@ -191,4 +193,4 @@ try {
   if (reg && reg.register && !reg.get('qwen')) reg.register('qwen', provider);
 } catch {}
 
-module.exports = provider;
+if (typeof module !== 'undefined') module.exports = provider;


### PR DESCRIPTION
## Summary
- guard provider exports and expose them on the global object
- ensure providers self-register with qwenProviders in browsers
- bump version to 1.28.3

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a221752bb48323a072acf996a3b7e1