### PR TITLE
Initialize provider registry before modules

### DIFF
--- a/src/pdfViewer.html
+++ b/src/pdfViewer.html
@@ -57,6 +57,7 @@
 <script src="lz-string.min.js"></script>
 <script src="cache.js"></script>
 <script src="lib/providers.js"></script>
+<script>window.qwenProviders?.init?.();</script>
 <script src="providers/qwen.js"></script>
 <script src="providers/dashscope.js"></script>
 <script src="providers/google.js"></script>

--- a/src/popup/settings.html
+++ b/src/popup/settings.html
@@ -82,8 +82,9 @@
     </section>
   </div>
 
-  <script src="../providerConfig.js"></script>
   <script src="../lib/providers.js"></script>
+  <script>window.qwenProviders?.init?.();</script>
+  <script src="../providerConfig.js"></script>
   <script src="../providers/qwen.js"></script>
   <script src="../providers/dashscope.js"></script>
   <script src="../providers/google.js"></script>


### PR DESCRIPTION
## Summary
- Load provider registry before provider modules on settings and PDF viewer pages
- Initialize registry upfront so provider scripts can register safely

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2239a5ccc8323834fb4661709c00a