### PR TITLE
Filter provider list to configured providers

### DIFF
--- a/src/popup/settings.js
+++ b/src/popup/settings.js
@@ -102,10 +102,21 @@
     const available = window.qwenProviders?.listProviders?.() || [];
     const providers = providerConfig.providers || {};
     providerConfig.providers = providers;
+    function isConfigured(name) {
+      const meta = available.find(p => p.name === name);
+      const fields = meta?.configFields || ['apiKey', 'apiEndpoint', 'model'];
+      const cfg = providers[name] || {};
+      for (const f of fields) {
+        if ((f === 'apiKey' || f === 'apiEndpoint') && !cfg[f]) return false;
+      }
+      return true;
+    }
     const order = Array.isArray(providerConfig.providerOrder)
-      ? providerConfig.providerOrder.slice()
+      ? providerConfig.providerOrder.filter(n => providers[n] && isConfigured(n))
       : [];
-    available.forEach(p => { if (!order.includes(p.name)) order.push(p.name); });
+    Object.keys(providers).forEach(n => {
+      if (isConfigured(n) && !order.includes(n)) order.push(n);
+    });
     let dragEl = null;
     function saveOrder() {
       providerConfig.providerOrder = Array.from(providerList.children).map(el => el.dataset.provider);

--- a/test/settings.providers.test.js
+++ b/test/settings.providers.test.js
@@ -35,7 +35,13 @@ describe('settings provider cards', () => {
       listProviders: jest.fn(() => [{ name: 'p1', label: 'P1' }, { name: 'p2', label: 'P2' }]),
     };
     window.qwenProviderConfig = {
-      loadProviderConfig: jest.fn(() => Promise.resolve({ providers: { p1: { enabled: true }, p2: { enabled: true } }, providerOrder: ['p1', 'p2'] })),
+      loadProviderConfig: jest.fn(() => Promise.resolve({
+        providers: {
+          p1: { enabled: true, apiKey: 'k1', apiEndpoint: 'https://e.com' },
+          p2: { enabled: true, apiKey: 'k2', apiEndpoint: 'https://e.com' },
+        },
+        providerOrder: ['p1', 'p2'],
+      })),
       saveProviderConfig: jest.fn(() => Promise.resolve()),
     };
   });


### PR DESCRIPTION
## Summary
- filter popup provider list to entries with required config
- ensure tests provide api details for new configuration check

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a243884da8832390a0e7edd4a1920f