### PR TITLE
Handle missing receivers in messaging

### DIFF
--- a/src/popup/diagnostics.js
+++ b/src/popup/diagnostics.js
@@ -31,6 +31,14 @@
   const log = [];
   let metrics = {};
 
+  function handleLastError(cb) {
+    return (...args) => {
+      const err = chrome.runtime.lastError;
+      if (err && !err.message.includes('Receiving end does not exist')) console.debug(err);
+      if (typeof cb === 'function') cb(...args);
+    };
+  }
+
   function updateSummary() {
     const requests = log.length;
     const tokens = log.reduce((s, e) => s + (e.tokens || 0), 0);
@@ -76,7 +84,7 @@
 
   async function load() {
     if (typeof chrome === 'undefined' || !chrome.runtime?.sendMessage) return;
-    metrics = await new Promise(resolve => chrome.runtime.sendMessage({ action: 'metrics' }, resolve));
+    metrics = await new Promise(resolve => chrome.runtime.sendMessage({ action: 'metrics' }, handleLastError(resolve)));
     render();
   }
 

--- a/src/popup/settings.js
+++ b/src/popup/settings.js
@@ -9,6 +9,14 @@
     selectionPopup: false,
   };
 
+  function handleLastError(cb) {
+    return (...args) => {
+      const err = chrome.runtime.lastError;
+      if (err && !err.message.includes('Receiving end does not exist')) console.debug(err);
+      if (typeof cb === 'function') cb(...args);
+    };
+  }
+
   const store = await new Promise(res => {
     if (chrome?.storage?.sync) chrome.storage.sync.get(defaults, res);
     else res(defaults);
@@ -68,7 +76,7 @@
     chrome?.storage?.sync?.set({ cacheEnabled: cacheBox.checked });
   });
   document.getElementById('clearCache')?.addEventListener('click', () => {
-    chrome?.runtime?.sendMessage({ action: 'clear-cache' });
+    chrome?.runtime?.sendMessage({ action: 'clear-cache' }, handleLastError());
   });
 
   const providerList = document.getElementById('providerList');
@@ -247,9 +255,9 @@
   }
 
   const usageEl = document.getElementById('usageStats');
-  chrome?.runtime?.sendMessage({ action: 'metrics' }, m => {
+  chrome?.runtime?.sendMessage({ action: 'metrics' }, handleLastError(m => {
     const usage = m && m.usage ? m.usage : {};
     usageEl.textContent = JSON.stringify(usage, null, 2);
-  });
+  }));
 })();
 

--- a/src/qa/usage.js
+++ b/src/qa/usage.js
@@ -1,5 +1,13 @@
 const metrics = [];
 
+function handleLastError(cb) {
+  return (...args) => {
+    const err = chrome.runtime.lastError;
+    if (err && !err.message.includes('Receiving end does not exist')) console.debug(err);
+    if (typeof cb === 'function') cb(...args);
+  };
+}
+
 const ctx = document.getElementById('usageChart').getContext('2d');
 const chart = new Chart(ctx, {
   type: 'line',
@@ -43,11 +51,11 @@ chrome.runtime.onMessage.addListener(msg => {
   }
 });
 
-chrome.runtime.sendMessage({ action: 'get-usage-log' }, resp => {
+chrome.runtime.sendMessage({ action: 'get-usage-log' }, handleLastError(resp => {
   if (resp && Array.isArray(resp.log)) {
     resp.log.forEach(addMetric);
   }
-});
+}));
 
 document.getElementById('exportBtn').onclick = () => {
   const rows = [['timestamp','tokens','latency']];

--- a/test/contentScript.test.js
+++ b/test/contentScript.test.js
@@ -40,7 +40,7 @@ test('emits progress updates during batch translation', async () => {
   expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({
     action: 'translation-status',
     status: expect.objectContaining({ active: true, phase: 'translate', request: 1, requests: 2, progress: expect.any(Object) })
-  }));
+  }), expect.any(Function));
 });
 
 test('skips reference superscripts', () => {

--- a/test/popup.test.js
+++ b/test/popup.test.js
@@ -46,17 +46,17 @@ describe('popup shell routing', () => {
 
     listener({ action: 'home:quick-translate' });
     expect(chrome.tabs.query).toHaveBeenCalledWith({ active: true, currentWindow: true }, expect.any(Function));
-    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'ensure-start', tabId: 1, url: 'https://example.com' });
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'ensure-start', tabId: 1, url: 'https://example.com' }, expect.any(Function));
 
     listener({ action: 'home:auto-translate', enabled: true });
     expect(chrome.storage.sync.set).toHaveBeenCalledWith({ autoTranslate: true });
-    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'set-config', config: { autoTranslate: true } });
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'set-config', config: { autoTranslate: true } }, expect.any(Function));
 
     listener({ action: 'home:auto-translate', enabled: false });
     expect(chrome.storage.sync.set).toHaveBeenCalledWith({ autoTranslate: false });
-    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'set-config', config: { autoTranslate: false } });
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'set-config', config: { autoTranslate: false } }, expect.any(Function));
     expect(chrome.tabs.query).toHaveBeenCalledWith({ active: true, currentWindow: true }, expect.any(Function));
-    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(1, { action: 'stop' });
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(1, { action: 'stop' }, expect.any(Function));
   });
 
   test('initializes home view via home:init', async () => {

--- a/test/popupCost.test.js
+++ b/test/popupCost.test.js
@@ -51,12 +51,12 @@ describe('home view display', () => {
     expect(document.getElementById('cacheStatus').textContent).toBe('Cache: 1/2 TM: 3/4');
 
     document.getElementById('quickTranslate').click();
-    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'home:quick-translate' });
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'home:quick-translate' }, expect.any(Function));
 
     const auto = document.getElementById('autoTranslate');
     auto.checked = true;
     auto.dispatchEvent(new Event('change'));
-    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'home:auto-translate', enabled: true });
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'home:auto-translate', enabled: true }, expect.any(Function));
   });
 });
 


### PR DESCRIPTION
## Summary
- wrap chrome.runtime.sendMessage and chrome.tabs.sendMessage in callbacks that log non-missing-receiver errors
- suppress "Receiving end does not exist" console noise across popup, background, and content scripts
- update tests for new callbacks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a24d5bfde4832389b04994508910e5