### PR TITLE
Debounce popup resize observer

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -25,13 +25,21 @@
     load(current === 'settings.html' ? 'home.html' : 'settings.html');
   });
 
+  let resizeObserver;
   function observeResize() {
     if (!frame) return;
     try {
       const doc = frame.contentDocument;
       if (!doc) return;
-      const ro = new ResizeObserver(resize);
-      ro.observe(doc.documentElement);
+      resizeObserver?.disconnect();
+      resizeObserver = new ResizeObserver(() => {
+        resizeObserver.disconnect();
+        requestAnimationFrame(() => {
+          resize();
+          resizeObserver.observe(doc.documentElement);
+        });
+      });
+      resizeObserver.observe(doc.documentElement);
     } catch {}
   }
   frame?.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- wrap ResizeObserver DOM writes in requestAnimationFrame
- disconnect and re-observe to avoid synchronous resize loops

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a24d13282883238d023fda6e1f6f61