### PR TITLE
fix: avoid process reference in browser context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.28.6",
+      "version": "1.28.7",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.26.3",
+  "version": "1.28.7",
   "version_name": "2025-08-18",
   "update_url": "https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/updates.xml",
   "permissions": [

--- a/src/translator.js
+++ b/src/translator.js
@@ -1,7 +1,7 @@
 (function () {
 // Only guard in real browser/extension contexts so tests can reload the module
 if (
-  process.env.NODE_ENV !== 'test' &&
+  (typeof process === 'undefined' || process.env.NODE_ENV !== 'test') &&
   typeof window !== 'undefined' &&
   typeof chrome !== 'undefined' &&
   chrome.runtime &&
@@ -990,7 +990,7 @@ if (typeof window !== 'undefined') {
   window.qwenClearCache = qwenClearCache;
   window.qwenSetTokenBudget = _setTokenBudget;
   if (
-    process.env.NODE_ENV !== 'test' &&
+    (typeof process === 'undefined' || process.env.NODE_ENV !== 'test') &&
     typeof chrome !== 'undefined' &&
     chrome.runtime &&
     chrome.runtime.id


### PR DESCRIPTION
## Summary
- guard against missing `process` global so translator works in extensions and service workers
- bump version to 1.28.7

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a253178fd48323965828cf0c4f8c37