### PR TITLE
Guard process access in config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
 (function () {
 // Guard only when running in the extension to allow test re-imports
 if (
-  process.env.NODE_ENV !== 'test' &&
+  (typeof process === 'undefined' || process.env.NODE_ENV !== 'test') &&
   typeof window !== 'undefined' &&
   typeof chrome !== 'undefined' &&
   chrome.runtime &&
@@ -162,7 +162,7 @@ if (typeof window !== 'undefined') {
   window.qwenSaveConfig = qwenSaveConfig;
   window.qwenModelTokenLimits = modelTokenLimits;
   if (
-    process.env.NODE_ENV !== 'test' &&
+    (typeof process === 'undefined' || process.env.NODE_ENV !== 'test') &&
     typeof chrome !== 'undefined' &&
     chrome.runtime &&
     chrome.runtime.id


### PR DESCRIPTION
## Summary
- guard `process` references in `src/config.js` to avoid ReferenceError outside Node

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a25997710883238f2e70dd07daef52