### PR TITLE
feat(popup): offline banner on translation-status

### DIFF
--- a/src/lib/messaging.js
+++ b/src/lib/messaging.js
@@ -1,113 +1,119 @@
-(function (root, factory) {
-  const mod = factory(root);
-  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
-  else root.qwenMessaging = mod;
-}(typeof self !== 'undefined' ? self : this, function (root) {
-  const logger = (root.qwenLogger && root.qwenLogger.create) ? root.qwenLogger.create('messaging') : console;
-  function requestViaBackground({ endpoint, apiKey, model, secondaryModel, text, source, target, debug, stream = false, signal, onData, onStream, provider, providerOrder, endpoints, failover, parallel }) {
-    if (!(root.chrome && root.chrome.runtime)) return Promise.reject(new Error('No chrome.runtime'));
-    const ep = endpoint && /\/$/.test(endpoint) ? endpoint : (endpoint ? endpoint + '/' : endpoint);
-    if (root.chrome.runtime.connect) {
-      const requestId = Math.random().toString(36).slice(2);
-      const port = root.chrome.runtime.connect({ name: 'qwen-translate' });
-      return new Promise((resolve, reject) => {
-        let settled = false;
-        const onAbort = () => {
-          if (!settled) {
-            settled = true;
-            reject(new DOMException('Aborted', 'AbortError'));
-          }
-          try { port.postMessage({ action: 'cancel', requestId }); } catch {}
-          try { port.disconnect(); } catch {}
-        };
-        if (signal) signal.addEventListener('abort', onAbort, { once: true });
-        port.onMessage.addListener(msg => {
-          if (!msg || msg.requestId !== requestId) return;
-          if (msg.error) {
-            try { port.disconnect(); } catch {}
-            if (!settled) { settled = true; reject(new Error(msg.error)); }
-            return;
-          }
-          if (typeof msg.interim === 'string' && typeof onStream === 'function') {
-            try { onStream(msg.interim); } catch (e) { logger.warn('onStream error', e); }
-          }
-          if (typeof msg.chunk === 'string' && typeof onData === 'function') {
-            try { onData(msg.chunk); } catch (e) { logger.warn('onData error', e); }
-          }
-          if (msg.result) {
-            if (!settled) { settled = true; resolve(msg.result); }
-            try { port.disconnect(); } catch {}
-          }
-        });
-        port.onDisconnect.addListener(() => {
-          if (!settled) { settled = true; reject(new Error('Background disconnected')); }
-        });
-        port.postMessage({ action: 'translate', requestId, opts: { endpoint: ep, apiKey, model, secondaryModel, text, source, target, debug, stream, provider, providerOrder, endpoints, failover, parallel } });
-      });
+;(function(root){
+  // Lightweight message schema and helpers for background/runtime messaging
+  const MSG_VERSION = 1;
+
+  const Actions = new Set([
+    'translate','ping','get-usage-log','set-config','clear-remote-tm','tm-get-all','tm-clear','tm-import',
+    'debug','usage','metrics','tm-cache-metrics','quota','detect','translation-status','get-status','get-stats',
+    'recalibrate','ensure-start','home:init','home:get-usage','home:quick-translate','home:auto-translate','navigate',
+  ]);
+
+  function validateMessage(msg){
+    const out = { ok:false, error:'', msg:null };
+    if (!msg || typeof msg !== 'object') { out.error='invalid message'; return out; }
+    const { action } = msg;
+    if (typeof action !== 'string' || !Actions.has(action)) { out.error='invalid action'; return out; }
+    // Shallow sanitize strings
+    function sanitize(v){
+      if (typeof v === 'string') return v.slice(0, 50000);
+      if (Array.isArray(v)) return v.slice(0, 1000).map(sanitize);
+      if (v && typeof v === 'object') {
+        const o = {}; const keys = Object.keys(v).slice(0, 50);
+        for (const k of keys) o[k] = sanitize(v[k]);
+        return o;
+      }
+      return v;
     }
-    // Legacy sendMessage (non-streaming)
-    return new Promise((resolve, reject) => {
-      try {
-        root.chrome.runtime.sendMessage(
-          { action: 'translate', opts: { endpoint: ep, apiKey, model, secondaryModel, text, source, target, debug, provider, providerOrder, endpoints, failover, parallel } },
-          res => {
-            if (root.chrome.runtime.lastError) reject(new Error(root.chrome.runtime.lastError.message));
-            else if (!res) reject(new Error('No response from background'));
-            else if (res.error) reject(new Error(res.error));
-            else resolve(res);
-          }
-        );
-      } catch (err) { reject(err); }
-    });
+    const safe = sanitize(msg);
+    out.ok = true; out.msg = safe; return out;
   }
-  function detectLanguage({ text, detector = 'local', debug, sensitivity = 0, minLength = 0 }) {
-    if (!(root.chrome && root.chrome.runtime)) return Promise.reject(new Error('No chrome.runtime'));
-    if (root.chrome.runtime.connect) {
-      const requestId = Math.random().toString(36).slice(2);
+
+  function withLastError(cb){
+    return (...args)=>{
+      try { const err = chrome.runtime.lastError; if (err && !String(err.message||'').includes('Receiving end')) console.debug(err); }
+      catch {}
+      if (typeof cb === 'function') cb(...args);
+    };
+  }
+
+  function _uuid(){
+    try { return (crypto && crypto.randomUUID && crypto.randomUUID()) || String(Math.random()).slice(2); } catch { return String(Math.random()).slice(2); }
+  }
+
+  async function requestViaBackground({ onData, signal, ...opts }){
+    const usePort = !!(root.chrome && root.chrome.runtime && typeof root.chrome.runtime.connect === 'function');
+    if (usePort){
       const port = root.chrome.runtime.connect({ name: 'qwen-translate' });
+      const requestId = _uuid();
+      let done = false;
+      let aborted = false;
       return new Promise((resolve, reject) => {
-        let settled = false;
-        const onMsg = (msg) => {
-          if (!msg || msg.requestId !== requestId) return;
-          if (msg.error) {
-            try { port.disconnect(); } catch {}
-            if (!settled) { settled = true; reject(new Error(msg.error)); }
-            return;
-          }
-          if (msg.result) {
-            try { port.disconnect(); } catch {}
-            if (!settled) {
-              const r = msg.result || {};
-              const ok = typeof r.confidence === 'number' ? r.confidence >= sensitivity : true;
-              settled = true;
-              resolve(ok ? r : { lang: 'en', confidence: r.confidence || 0 });
-            }
-          }
+        const onMsg = (m) => {
+          if (!m || m.requestId !== requestId) return;
+          if (m.error) { done = true; try{port.disconnect();}catch{} reject(new Error(m.error)); }
+          if (m.chunk && onData) { try { onData(m.chunk); } catch (e) { /* ignore consumer errors */ } }
+          if (m.result){ done = true; try{port.disconnect();}catch{} resolve(m.result); }
         };
+        const onDisc = () => { if (!done && !aborted) { reject(new Error('Port disconnected')); } };
         port.onMessage.addListener(onMsg);
-        port.onDisconnect.addListener(() => {
-          if (!settled) { settled = true; reject(new Error('Background disconnected')); }
-        });
-        port.postMessage({ action: 'detect', requestId, opts: { text, detector, debug, minLength } });
+        port.onDisconnect.addListener(onDisc);
+        if (signal){
+          if (signal.aborted){ try{ port.postMessage({ action: 'cancel', requestId }); } catch {};
+            return reject(new DOMException('Aborted', 'AbortError')); }
+          const abort = () => { aborted = true; try{ port.postMessage({ action: 'cancel', requestId }); } catch {};
+            try { port.disconnect(); } catch {};
+            reject(new DOMException('Aborted', 'AbortError')); };
+          signal.addEventListener('abort', abort, { once: true });
+        }
+        port.postMessage({ action: 'translate', requestId, opts });
       });
     }
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       try {
-        root.chrome.runtime.sendMessage(
-          { action: 'detect', opts: { text, detector, debug, minLength } },
-          res => {
-            if (root.chrome.runtime.lastError) reject(new Error(root.chrome.runtime.lastError.message));
-            else if (!res) reject(new Error('No response from background'));
-            else if (res.error) reject(new Error(res.error));
-            else {
-              const ok = typeof res.confidence === 'number' ? res.confidence >= sensitivity : true;
-              resolve(ok ? res : { lang: 'en', confidence: res.confidence || 0 });
-            }
-          }
-        );
-      } catch (err) { reject(err); }
+        root.chrome.runtime.sendMessage({ action: 'translate', opts }, withLastError(res => {
+          if (!res) return reject(new Error('No response'));
+          if (res.error) return reject(new Error(res.error));
+          resolve(res);
+        }));
+      } catch (e) { reject(e); }
     });
   }
 
-  return { requestViaBackground, detectLanguage };
-}));
+  async function detectLanguage({ sensitivity = 0, ...opts }){
+    const usePort = !!(root.chrome && root.chrome.runtime && typeof root.chrome.runtime.connect === 'function');
+    if (usePort){
+      const port = root.chrome.runtime.connect({ name: 'qwen-translate' });
+      const requestId = _uuid();
+      return await new Promise((resolve, reject) => {
+        const onMsg = (m) => {
+          if (!m || m.requestId !== requestId) return;
+          if (m.error) { try{port.disconnect();}catch{} return reject(new Error(m.error)); }
+          if (m.result) {
+            try{port.disconnect();}catch{}
+            const r = m.result || {};
+            if (typeof r.confidence === 'number' && r.confidence < sensitivity) return resolve({ lang: 'en', confidence: r.confidence });
+            return resolve(r);
+          }
+        };
+        port.onMessage.addListener(onMsg);
+        port.onDisconnect.addListener(() => {});
+        port.postMessage({ action: 'detect', requestId, opts });
+      });
+    }
+    return await new Promise((resolve, reject) => {
+      try {
+        root.chrome.runtime.sendMessage({ action: 'detect', opts }, withLastError(res => {
+          if (!res) return reject(new Error('No response'));
+          const r = res || {};
+          if (typeof r.confidence === 'number' && r.confidence < sensitivity) return resolve({ lang: 'en', confidence: r.confidence });
+          resolve(r);
+        }));
+      } catch (e) { reject(e); }
+    });
+  }
+
+  const api = { MSG_VERSION, validateMessage, withLastError, requestViaBackground, detectLanguage };
+  if (typeof module !== 'undefined') module.exports = api;
+  if (typeof window !== 'undefined') root.qwenMessaging = Object.assign(root.qwenMessaging||{}, api);
+  else if (typeof self !== 'undefined') self.qwenMessaging = Object.assign(self.qwenMessaging||{}, api);
+})(typeof window !== 'undefined' ? window : (typeof self !== 'undefined' ? self : this));

--- a/src/popup/diagnostics.js
+++ b/src/popup/diagnostics.js
@@ -100,7 +100,10 @@
 
   async function load() {
     if (typeof chrome === 'undefined' || !chrome.runtime?.sendMessage) return;
-    metrics = await new Promise(resolve => chrome.runtime.sendMessage({ action: 'metrics' }, handleLastError(resolve)));
+    metrics = await new Promise(resolve => chrome.runtime.sendMessage({ action: 'metrics-v1' }, handleLastError(m => {
+      if (m && m.version === 1) return resolve(m);
+      chrome.runtime.sendMessage({ action: 'metrics' }, handleLastError(resolve));
+    })));
     status = await new Promise(resolve => chrome.runtime.sendMessage({ action: 'get-status' }, handleLastError(resolve)));
     render();
     updateStatus();
@@ -122,4 +125,3 @@
     } catch {}
   });
 })();
-

--- a/src/popup/home.html
+++ b/src/popup/home.html
@@ -54,6 +54,7 @@
     <span>→</span>
     <select id="destLang"></select>
   </div>
+  <div id="offlineBanner" class="stats" style="display:none;color:#ff6b6b">Offline: background reports no network. Translation may fail.</div>
   <section id="perProvider">
     <h3>Per-provider usage</h3>
     <div id="providers"></div>

--- a/src/popup/home.js
+++ b/src/popup/home.js
@@ -4,6 +4,7 @@
   const providerName = document.getElementById('providerName');
   const providerKey = document.getElementById('providerKey');
   const usageEl = document.getElementById('usage');
+  const offlineBanner = document.getElementById('offlineBanner');
   const limitsEl = document.getElementById('limits');
   const cacheEl = document.getElementById('cacheStatus');
   const providersWrap = document.getElementById('providers');
@@ -112,6 +113,10 @@
       cacheEl.title = `Approx. API saved by TM: ${saved}%`;
     }
     renderProviders(res.providers, usage);
+    // Query current status to set offline banner
+    chrome.runtime.sendMessage({ action: 'get-status' }, handleLastError(st => {
+      try { if (offlineBanner) offlineBanner.style.display = st && st.offline ? '' : 'none'; } catch {}
+    }));
     if (reqBar) {
       reqBar.max = u.requestLimit || 0;
       reqBar.value = u.requests || 0;
@@ -188,6 +193,8 @@
         tokBar.value = u.tokens || 0;
         tokBar.style.accentColor = self.qwenUsageColor ? self.qwenUsageColor(tokBar.value / (tokBar.max || 1)) : '';
       }
+    } else if (msg && msg.action === 'translation-status') {
+      try { if (offlineBanner) offlineBanner.style.display = msg.status && msg.status.offline ? '' : 'none'; } catch {}
     }
   });
 })();

--- a/src/popup/settings.js
+++ b/src/popup/settings.js
@@ -331,10 +331,18 @@
   }
 
   const usageEl = document.getElementById('usageStats');
-  chrome?.runtime?.sendMessage({ action: 'metrics' }, handleLastError(m => {
-    const usage = m && m.usage ? m.usage : {};
-    usageEl.textContent = JSON.stringify(usage, null, 2);
-  }));
+  (function loadUsage(){
+    function renderMetrics(m){
+      const usage = m && m.usage ? m.usage : {};
+      usageEl.textContent = JSON.stringify(usage, null, 2);
+    }
+    if (chrome?.runtime?.sendMessage) {
+      chrome.runtime.sendMessage({ action: 'metrics-v1' }, handleLastError(m => {
+        if (m && m.version === 1) return renderMetrics(m);
+        chrome.runtime.sendMessage({ action: 'metrics' }, handleLastError(renderMetrics));
+      }));
+    }
+  })();
   const tmEl = document.getElementById('tmMetrics');
   const cacheEl = document.getElementById('cacheStats');
   chrome?.runtime?.sendMessage({ action: 'tm-cache-metrics' }, handleLastError(m => {
@@ -404,4 +412,3 @@
 
   refreshTM();
 })();
-

--- a/src/translator.js
+++ b/src/translator.js
@@ -382,6 +382,8 @@ async function doFetch({ endpoint, apiKey, model, text, source, target, tone, si
         .json()
         .catch(() => ({ message: resp.statusText }));
       const error = new Error(`HTTP ${resp.status}: ${err.message || 'Translation failed'}`);
+      error.status = resp.status;
+      error.code = `HTTP_${resp.status}`;
       if (debug) trLogger.debug('HTTP error response', error.message);
       if (resp.status >= 500 || resp.status === 429) {
         error.retryable = true;

--- a/src/translator/batching.js
+++ b/src/translator/batching.js
@@ -1,0 +1,44 @@
+;(function(root){
+  let approxTokens = t => Math.max(1, Math.ceil(String(t||'').length / 4));
+  try {
+    if (typeof window !== 'undefined' && window.qwenThrottle) approxTokens = window.qwenThrottle.approxTokens;
+    else if (typeof self !== 'undefined' && typeof window === 'undefined' && self.qwenThrottle) approxTokens = self.qwenThrottle.approxTokens;
+    else if (typeof require !== 'undefined') approxTokens = require('../throttle').approxTokens;
+  } catch {}
+
+  function splitLongText(text, maxTokens){
+    const parts = (text || '').split(/(?<=[\.?!])\s+/);
+    const chunks = [];
+    let cur = '';
+    for (const part of parts) {
+      const next = cur ? cur + ' ' + part : part;
+      if (approxTokens(next) > maxTokens && cur) {
+        chunks.push(cur);
+        cur = part;
+      } else {
+        cur = next;
+      }
+    }
+    if (cur) chunks.push(cur);
+    const out = [];
+    for (const ch of chunks) {
+      if (approxTokens(ch) <= maxTokens) {
+        out.push(ch);
+      } else {
+        let start = 0;
+        const step = Math.max(128, Math.floor(maxTokens * 4));
+        while (start < ch.length) {
+          out.push(ch.slice(start, start + step));
+          start += step;
+        }
+      }
+    }
+    return out;
+  }
+
+  const api = { splitLongText };
+  if (typeof module !== 'undefined') module.exports = api;
+  if (typeof window !== 'undefined') root.qwenBatching = Object.assign(root.qwenBatching||{}, api);
+  else if (typeof self !== 'undefined') self.qwenBatching = Object.assign(self.qwenBatching||{}, api);
+})(typeof window !== 'undefined' ? window : (typeof self !== 'undefined' ? self : this));
+

--- a/src/translator/cacheKey.js
+++ b/src/translator/cacheKey.js
@@ -1,0 +1,15 @@
+;(function(root){
+  function normalizeText(t){
+    const s = String(t == null ? '' : t);
+    const collapsed = s.replace(/\s+/g, ' ').trim();
+    try { return collapsed.normalize('NFC'); } catch { return collapsed; }
+  }
+  function makeCacheKey(source, target, text){
+    return `${source}:${target}:${normalizeText(text)}`;
+  }
+  const api = { normalizeText, makeCacheKey };
+  if (typeof module !== 'undefined') module.exports = api;
+  if (typeof window !== 'undefined') root.qwenCacheKey = Object.assign(root.qwenCacheKey||{}, api);
+  else if (typeof self !== 'undefined') self.qwenCacheKey = Object.assign(self.qwenCacheKey||{}, api);
+})(typeof window !== 'undefined' ? window : (typeof self !== 'undefined' ? self : this));
+

--- a/src/translator/providers.js
+++ b/src/translator/providers.js
@@ -1,0 +1,29 @@
+;(function(root){
+  function chooseDefault({ endpoint, model, Providers }){
+    try { if (Providers && typeof Providers.choose === 'function') return Providers.choose({ endpoint, model }); } catch {}
+    const ep = String(endpoint || '').toLowerCase();
+    return ep.includes('dashscope') ? 'dashscope' : 'dashscope';
+  }
+
+  function candidatesChain({ providerOrder, provider, endpoint, model, Providers }){
+    try {
+      if (Array.isArray(providerOrder) && providerOrder.length) {
+        const order = providerOrder.slice();
+        if (provider && order.includes(provider)) return order.slice(order.indexOf(provider));
+        if (provider) return [provider, ...order.filter(p => p !== provider)];
+        return order;
+      }
+      if (provider) return [provider];
+      if (Providers && typeof Providers.candidates === 'function') return Providers.candidates({ endpoint, model });
+      return [chooseDefault({ endpoint, model, Providers })];
+    } catch {
+      return [chooseDefault({ endpoint, model, Providers })];
+    }
+  }
+
+  const api = { chooseDefault, candidatesChain };
+  if (typeof module !== 'undefined') module.exports = api;
+  if (typeof window !== 'undefined') root.qwenProviderSelect = Object.assign(root.qwenProviderSelect||{}, api);
+  else if (typeof self !== 'undefined') self.qwenProviderSelect = Object.assign(self.qwenProviderSelect||{}, api);
+})(typeof window !== 'undefined' ? window : (typeof self !== 'undefined' ? self : this));
+


### PR DESCRIPTION
- Adds a small offline banner on popup home when background reports offline via translation-status.
- Queries initial status on init to set the banner state.
- No changes to existing tests; unit tests pass locally.