### PR TITLE
refactor: extract provider selection (v2)

### DIFF
--- a/src/translator/providers.js
+++ b/src/translator/providers.js
@@ -1,0 +1,29 @@
+;(function(root){
+  function chooseDefault({ endpoint, model, Providers }){
+    try { if (Providers && typeof Providers.choose === 'function') return Providers.choose({ endpoint, model }); } catch {}
+    const ep = String(endpoint || '').toLowerCase();
+    return ep.includes('dashscope') ? 'dashscope' : 'dashscope';
+  }
+
+  function candidatesChain({ providerOrder, provider, endpoint, model, Providers }){
+    try {
+      if (Array.isArray(providerOrder) && providerOrder.length) {
+        const order = providerOrder.slice();
+        if (provider && order.includes(provider)) return order.slice(order.indexOf(provider));
+        if (provider) return [provider, ...order.filter(p => p !== provider)];
+        return order;
+      }
+      if (provider) return [provider];
+      if (Providers && typeof Providers.candidates === 'function') return Providers.candidates({ endpoint, model });
+      return [chooseDefault({ endpoint, model, Providers })];
+    } catch {
+      return [chooseDefault({ endpoint, model, Providers })];
+    }
+  }
+
+  const api = { chooseDefault, candidatesChain };
+  if (typeof module !== 'undefined') module.exports = api;
+  if (typeof window !== 'undefined') root.qwenProviderSelect = Object.assign(root.qwenProviderSelect||{}, api);
+  else if (typeof self !== 'undefined') self.qwenProviderSelect = Object.assign(self.qwenProviderSelect||{}, api);
+})(typeof window !== 'undefined' ? window : (typeof self !== 'undefined' ? self : this));
+


### PR DESCRIPTION
Rebased variant of #374 on latest main to resolve merge conflicts. Extracts provider selection helpers to src/translator/providers.js with UMD export and fallback. Tests pass.