### PR TITLE
feat: diagnostics quality (avg/P50/P95) + chart; tests for provider error normalization

### DIFF
--- a/src/popup/diagnostics.html
+++ b/src/popup/diagnostics.html
@@ -16,8 +16,9 @@
   <h3>Diagnostics</h3>
   <div class="section" id="status"></div>
   <div class="section" id="usage"></div>
+  <div class="section" id="quality"></div>
   <div class="section" id="usageSummary"></div>
-  <canvas id="usageChart"></canvas>
+  <canvas id="usageChart" width="320" height="80" style="background: var(--qwen-secondary-bg, rgba(118,118,128,0.2)); border:1px solid var(--qwen-border, rgba(255,255,255,0.2)); border-radius:4px;"></canvas>
   <div class="section" id="cache"></div>
   <ul id="providers"></ul>
   <button id="back" class="secondary">Back</button>
@@ -25,4 +26,3 @@
   <script src="diagnostics.js"></script>
 </body>
 </html>
-

--- a/test/providers.errorNormalization.test.js
+++ b/test/providers.errorNormalization.test.js
@@ -1,0 +1,37 @@
+// @jest-environment node
+
+describe('provider error normalization', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    fetch.resetMocks();
+  });
+
+  function mockResp(status, body = { error: { message: 'x' } }, headers = {}) {
+    const h = new Headers(headers);
+    fetch.mockResponseOnce(JSON.stringify(body), { status, headers: h });
+  }
+
+  test('openai: 401 sets retryable=false', async () => {
+    const openai = require('../src/providers/openai.js');
+    mockResp(401, { error: { message: 'unauthorized' } });
+    await expect(openai.translate({ endpoint: 'https://api.openai.com/v1', apiKey: 'bad', model: 'gpt', text: 't', source: 'en', target: 'es', stream: false }))
+      .rejects.toMatchObject({ status: 401, retryable: false });
+  });
+
+  test('openai: 429 sets retryable=true and parses Retry-After', async () => {
+    const openai = require('../src/providers/openai.js');
+    mockResp(429, { error: { message: 'too many' } }, { 'retry-after': '2' });
+    const p = openai.translate({ endpoint: 'https://api.openai.com/v1', apiKey: 'k', model: 'gpt', text: 't', source: 'en', target: 'es', stream: false });
+    await expect(p).rejects.toMatchObject({ status: 429, retryable: true, retryAfter: expect.any(Number) });
+  });
+
+  test('deepl: 403 retryable=false; 500 retryable=true', async () => {
+    const deepl = require('../src/providers/deepl.js');
+    mockResp(403, { message: 'forbidden' });
+    await expect(deepl.translate({ apiKey: 'bad', text: 't', source: 'en', target: 'es' })).rejects.toMatchObject({ status: 403, retryable: false });
+    fetch.resetMocks();
+    mockResp(500, { message: 'server' });
+    await expect(deepl.translate({ apiKey: 'k', text: 't', source: 'en', target: 'es' })).rejects.toMatchObject({ status: 500, retryable: true });
+  });
+});
+


### PR DESCRIPTION
- Diagnostics: show latency avg/P50/P95 and draw a simple line chart from usage log; prefer metrics-v1.
- Background: compute latency percentiles (P50/P95) and expose via metrics-v1 quality.
- Providers: normalize HTTP errors consistently (status/code/retryAfter + retryable rules).
- Tests: add provider error normalization tests covering 401/403 vs 429/5xx.
- All unit tests pass locally.