### PR TITLE
Map known endpoints to provider IDs

### DIFF
--- a/src/translator/providers.js
+++ b/src/translator/providers.js
@@ -2,7 +2,17 @@
   function chooseDefault({ endpoint, model, Providers }){
     try { if (Providers && typeof Providers.choose === 'function') return Providers.choose({ endpoint, model }); } catch {}
     const ep = String(endpoint || '').toLowerCase();
-    return ep.includes('dashscope') ? 'dashscope' : 'dashscope';
+    if (ep.includes('openrouter')) return 'openrouter';
+    if (ep.includes('openai')) return 'openai';
+    if (ep.includes('anthropic') || ep.includes('claude')) return 'anthropic';
+    if (ep.includes('mistral')) return 'mistral';
+    if (ep.includes('deepl')) return 'deepl';
+    if (ep.includes('google')) return 'google';
+    if (ep.includes('ollama') || ep.includes('11434')) return 'ollama';
+    if (ep.includes('gemini')) return 'gemini';
+    if (ep.includes('macos')) return 'macos';
+    if (ep.includes('dashscope') || ep.includes('qwen')) return 'dashscope';
+    return 'dashscope';
   }
 
   function candidatesChain({ providerOrder, provider, endpoint, model, Providers }){

--- a/test/translator.providers.chooseDefault.test.js
+++ b/test/translator.providers.chooseDefault.test.js
@@ -1,0 +1,22 @@
+// @jest-environment node
+const { chooseDefault } = require('../src/translator/providers');
+
+describe('chooseDefault provider mapping', () => {
+  const cases = [
+    ['https://api.openai.com/v1', 'openai'],
+    ['https://api.deepl.com', 'deepl'],
+    ['https://translation.googleapis.com', 'google'],
+    ['https://openrouter.ai/api/v1', 'openrouter'],
+    ['https://api.anthropic.com', 'anthropic'],
+    ['https://api.mistral.ai', 'mistral'],
+    ['http://localhost:11434', 'ollama'],
+  ];
+
+  test.each(cases)('maps %s to %s', (endpoint, expected) => {
+    expect(chooseDefault({ endpoint })).toBe(expected);
+  });
+
+  test('falls back to dashscope for unknown endpoints', () => {
+    expect(chooseDefault({ endpoint: 'https://example.com' })).toBe('dashscope');
+  });
+});


### PR DESCRIPTION
## Summary
- map common translation API endpoints to provider IDs in `chooseDefault`
- add tests ensuring each endpoint resolves to the expected provider

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4664ec158832395006fd92fd2f7a9