### PR TITLE
Handle circular references in sanitizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.38.0",
+  "version": "1.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.38.0",
+      "version": "1.40.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/lib/messaging.js
+++ b/src/lib/messaging.js
@@ -13,11 +13,13 @@
     if (!msg || typeof msg !== 'object') { out.error='invalid message'; return out; }
     const { action } = msg;
     if (typeof action !== 'string' || !Actions.has(action)) { out.error='invalid action'; return out; }
-    // Shallow sanitize strings
+    const visited = new WeakSet();
     function sanitize(v){
       if (typeof v === 'string') return v.slice(0, 50000);
       if (Array.isArray(v)) return v.slice(0, 1000).map(sanitize);
       if (v && typeof v === 'object') {
+        if (visited.has(v)) return '[Circular]';
+        visited.add(v);
         const o = {}; const keys = Object.keys(v).slice(0, 50);
         for (const k of keys) o[k] = sanitize(v[k]);
         return o;

--- a/test/messaging.sanitize.test.js
+++ b/test/messaging.sanitize.test.js
@@ -1,0 +1,11 @@
+const messaging = require('../src/lib/messaging.js');
+
+describe('messaging.validateMessage sanitize', () => {
+  test('handles self-referential objects without infinite recursion', () => {
+    const msg = { action: 'ping' };
+    msg.self = msg;
+    const out = messaging.validateMessage(msg);
+    expect(out.ok).toBe(true);
+    expect(out.msg.self).toBe('[Circular]');
+  });
+});


### PR DESCRIPTION
## Summary
- avoid infinite recursion when sanitizing messages by tracking visited objects
- add unit test for self-referential messages
- bump version to 1.40.0

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4669315d88323b9cbdf5a089242fe