### PR TITLE
Add translator batching and cache stats tests

### DIFF
--- a/test/translator.batching.test.js
+++ b/test/translator.batching.test.js
@@ -1,0 +1,24 @@
+// @jest-environment node
+const { splitLongText } = require('../src/translator/batching.js');
+
+describe('translator batching splitLongText', () => {
+  test('splits at sentence boundaries', () => {
+    const text = 'One two. Three four. Five six.';
+    const chunks = splitLongText(text, 2);
+    expect(chunks).toEqual(['One two.', 'Three four.', 'Five six.']);
+  });
+
+  test('handles long paragraphs without punctuation', () => {
+    const text = 'a'.repeat(1000);
+    const chunks = splitLongText(text, 100);
+    expect(chunks).toHaveLength(3); // step 400 => 3 chunks
+    chunks.forEach(ch => expect(ch.length).toBeLessThanOrEqual(400));
+  });
+
+  test('splits overlong sentences respecting token limits', () => {
+    const text = `${'a'.repeat(500)}. Next sentence.`;
+    const chunks = splitLongText(text, 50);
+    expect(chunks).toHaveLength(4);
+    expect(chunks[3]).toBe('Next sentence.');
+  });
+});

--- a/test/translator.cacheStats.test.js
+++ b/test/translator.cacheStats.test.js
@@ -5,6 +5,27 @@ describe('translator cache stats', () => {
     jest.resetModules();
   });
 
+  test('counts words for uncached translations', async () => {
+    const Providers = require('../src/lib/providers.js');
+    Providers.reset();
+    const provider = { translate: jest.fn(async ({ text }) => ({ text: `T:${text}` })) };
+    Providers.register('mock', provider);
+    Providers.init();
+    const tr = require('../src/translator.js');
+    tr.qwenClearCache();
+    const res = await tr.qwenTranslateBatch({
+      texts: ['hello world'],
+      source: 'en',
+      target: 'fr',
+      providerOrder: ['mock'],
+      noProxy: true,
+    });
+    expect(provider.translate).toHaveBeenCalledTimes(1);
+    expect(res.stats.words).toBeGreaterThan(0);
+    expect(res.stats.tokens).toBeGreaterThan(0);
+    expect(res.stats.requests).toBe(1);
+  });
+
   test('counts words for cached translations', async () => {
     const Providers = require('../src/lib/providers.js');
     Providers.reset();

--- a/test/translator.providers.chooseDefault.test.js
+++ b/test/translator.providers.chooseDefault.test.js
@@ -1,22 +1,35 @@
 // @jest-environment node
-const { chooseDefault } = require('../src/translator/providers');
+const { chooseDefault, candidatesChain } = require('../src/translator/providers');
+const cases = [
+  ['https://api.openai.com/v1', 'openai'],
+  ['https://api.deepl.com', 'deepl'],
+  ['https://translation.googleapis.com', 'google'],
+  ['https://openrouter.ai/api/v1', 'openrouter'],
+  ['https://api.anthropic.com', 'anthropic'],
+  ['https://api.mistral.ai', 'mistral'],
+  ['http://localhost:11434', 'ollama'],
+];
 
 describe('chooseDefault provider mapping', () => {
-  const cases = [
-    ['https://api.openai.com/v1', 'openai'],
-    ['https://api.deepl.com', 'deepl'],
-    ['https://translation.googleapis.com', 'google'],
-    ['https://openrouter.ai/api/v1', 'openrouter'],
-    ['https://api.anthropic.com', 'anthropic'],
-    ['https://api.mistral.ai', 'mistral'],
-    ['http://localhost:11434', 'ollama'],
-  ];
-
   test.each(cases)('maps %s to %s', (endpoint, expected) => {
     expect(chooseDefault({ endpoint })).toBe(expected);
   });
 
   test('falls back to dashscope for unknown endpoints', () => {
     expect(chooseDefault({ endpoint: 'https://example.com' })).toBe('dashscope');
+  });
+});
+
+describe('candidatesChain failover order', () => {
+  test.each(cases)('candidates for %s start with %s', (endpoint, expected) => {
+    expect(candidatesChain({ endpoint })).toEqual([expected]);
+  });
+
+  test('defaults to dashscope when endpoint unknown', () => {
+    expect(candidatesChain({ endpoint: 'https://example.com' })).toEqual(['dashscope']);
+  });
+
+  test('uses providerOrder for failover', () => {
+    expect(candidatesChain({ providerOrder: ['openai', 'dashscope'] })).toEqual(['openai', 'dashscope']);
   });
 });


### PR DESCRIPTION
## Summary
- extend cache stats tests to ensure hits skip provider calls and track words/tokens/requests
- add batching splitLongText edge case tests for long text and token limits
- verify provider selection failover chains and default mapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a46e8598e48323acd720a7c29daa7e