### PR TITLE
test: expand logger redaction coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Start static server
         run: |
-          nohup npm run serve &
+          nohup npx http-server . -p 8080 &
           for i in {1..60}; do
             curl -sSf http://127.0.0.1:8080 >/dev/null && break || sleep 1;
           done
@@ -97,7 +97,7 @@ jobs:
           path: playwright-report
 
   automerge:
-    needs: build-and-test
+    needs: [build-and-test, e2e-smoke]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- expand logger redaction tests to cover deeply nested structures, arrays, and Error object fields
- serve repository root in e2e smoke workflow so Playwright tests load mock assets
- gate automerge on e2e smoke completion

## Testing
- `npm test`
- `npm run test:e2e:web`
- `npm run test:e2e:pdf`


------
https://chatgpt.com/codex/tasks/task_e_68a46f6062b88323a47793b1920ace70