### PR TITLE
fix: stabilize settings popup width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.40.0",
+      "version": "1.41.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.33.3",
+  "version": "1.34.0",
   "version_name": "2025-08-19",
   "update_url": "https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/updates.xml",
   "permissions": [

--- a/src/popup/settings.html
+++ b/src/popup/settings.html
@@ -11,6 +11,7 @@
       margin: 0;
       padding: 1rem;
       color: var(--qwen-text, #f5f5f7);
+      width: 360px;
     }
     .tabs { display: flex; gap: 0.5rem; margin-bottom: 0.5rem; }
     .tabs button {
@@ -34,6 +35,11 @@
     #addProviderOverlay .modal { background: var(--qwen-bg, rgba(28,28,30,0.9)); padding: 1rem; border: 1px solid var(--qwen-border, rgba(255,255,255,0.2)); min-width: 260px; }
     #addProviderOverlay .actions { display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 0.5rem; }
     #addProviderOverlay label { display: block; margin-bottom: 0.5rem; }
+    #tmEntries, #tmStats {
+      white-space: pre-wrap;
+      word-break: break-word;
+      overflow-x: auto;
+    }
   </style>
 </head>
 <body>

--- a/src/popup/settings.js
+++ b/src/popup/settings.js
@@ -64,11 +64,15 @@
     diagnostics: document.getElementById('diagnosticsTab'),
   };
 
+  const fixedWidth = document.body.clientWidth;
+  document.body.style.width = `${fixedWidth}px`;
+
   function activate(tab) {
     tabs.forEach(b => b.classList.toggle('active', b.dataset.tab === tab));
     Object.entries(sections).forEach(([k, el]) => {
       el.classList.toggle('active', k === tab);
     });
+    document.body.style.width = `${fixedWidth}px`;
   }
 
   activate(store.settingsTab);

--- a/updates.xml
+++ b/updates.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gupdate xmlns="http://www.google.com/update2/response" protocol="2.0">
   <app appid="YOUR_EXTENSION_ID">
-    <updatecheck codebase="https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/qwen-translator-extension.crx" version="1.33.3" />
+    <updatecheck codebase="https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/qwen-translator-extension.crx" version="1.34.0" />
   </app>
 </gupdate>


### PR DESCRIPTION
## Summary
- lock settings popup width to 360px and wrap translation memory output
- keep popup width fixed across tab switches
- bump version to 1.41.0 / 1.34.0
- remove binary screenshot from docs
- restore mupdf engine stub to avoid committing large vendor asset

## Testing
- `npm test`
- `npm run test:e2e:web`
- `npm run test:e2e:pdf`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_68a4752af0e48323bde20629caf7d9de