### PR TITLE
Add shared throttle integration test

### DIFF
--- a/test/provider.throttle.integration.test.js
+++ b/test/provider.throttle.integration.test.js
@@ -1,0 +1,27 @@
+// @jest-environment node
+const { createThrottle } = require('../src/throttle');
+
+jest.useFakeTimers();
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+describe('shared throttle across providers', () => {
+  test('queues requests when limit exceeded', async () => {
+    const shared = createThrottle({ requestLimit: 1, windowMs: 1000 });
+    const order = [];
+
+    shared.runWithRateLimit(() => Promise.resolve(order.push('p1')), 'a', { immediate: true });
+    shared.runWithRateLimit(() => Promise.resolve(order.push('p2')), 'b', { immediate: true });
+
+    await Promise.resolve();
+    expect(order).toEqual(['p1']);
+    expect(shared.getUsage().queue).toBe(1);
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+    expect(order).toEqual(['p1', 'p2']);
+    expect(shared.getUsage().queue).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add integration test covering shared throttle queuing behaviour

## Testing
- `npm test`
- `npm test test/provider.throttle.integration.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a46f6664a88323961163399a5bfe58