### PR TITLE
Cache WASM assets in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,14 +30,25 @@ jobs:
           key: ${{ runner.os }}-wasm-${{ hashFiles('scripts/fetch-wasm-assets.sh') }}
 
       - name: Install deps
-        run: npm install --no-audit --no-fund --ignore-scripts
+        run: npm ci --no-audit --no-fund
 
       - name: Fetch WASM assets
         if: steps.wasm-cache.outputs.cache-hit != 'true'
         run: bash scripts/fetch-wasm-assets.sh
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: |
+          echo "version=$(node -p \"require('playwright/package.json').version\")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ hashFiles('playwright.config.js') }}
+
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps chromium
 
       - name: Check repo for public PDFs at root (privacy)
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,8 +22,19 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Cache WASM assets
+        id: wasm-cache
+        uses: actions/cache@v4
+        with:
+          path: src/wasm/vendor
+          key: ${{ runner.os }}-wasm-${{ hashFiles('scripts/fetch-wasm-assets.sh') }}
+
       - name: Install deps
-        run: npm install --no-audit --no-fund
+        run: npm install --no-audit --no-fund --ignore-scripts
+
+      - name: Fetch WASM assets
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        run: bash scripts/fetch-wasm-assets.sh
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,11 +32,14 @@ jobs:
           path: src/wasm/vendor
           key: ${{ runner.os }}-wasm-${{ hashFiles('scripts/fetch-wasm-assets.sh') }}
       - name: Install deps
-        run: npm install --no-audit --no-fund --ignore-scripts
+        run: npm ci --no-audit --no-fund
+
       - name: Fetch WASM assets
         if: steps.wasm-cache.outputs.cache-hit != 'true'
         run: bash scripts/fetch-wasm-assets.sh
+
       - name: Type check
         run: npm run typecheck
+
       - name: Run unit tests with coverage
         run: npm test -- --coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,17 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+      - name: Cache WASM assets
+        id: wasm-cache
+        uses: actions/cache@v4
+        with:
+          path: src/wasm/vendor
+          key: ${{ runner.os }}-wasm-${{ hashFiles('scripts/fetch-wasm-assets.sh') }}
       - name: Install deps
-        run: npm install --no-audit --no-fund
+        run: npm install --no-audit --no-fund --ignore-scripts
+      - name: Fetch WASM assets
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        run: bash scripts/fetch-wasm-assets.sh
       - name: Type check
         run: npm run typecheck
       - name: Run unit tests with coverage


### PR DESCRIPTION
## Summary
- cache WASM vendor assets during CI
- skip asset download when cache is hit

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4826293008323add6e8e11629ac0a