### PR TITLE
chore: run Playwright e2e tests in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,8 @@ jobs:
             curl -sSf http://127.0.0.1:8080 >/dev/null && break || sleep 1;
           done
 
-      - name: Run e2e web smoke
-        run: npm run test:e2e:web
-
-      - name: Run e2e PDF compare
-        run: npm run test:e2e:pdf
+      - name: Run e2e tests
+        run: npm run test:e2e
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,6 +50,6 @@ jobs:
           fi
 
       - name: Run E2E tests
-        run: npm run e2e
+        run: npm run test:e2e
 
       # Privacy: do not upload screenshots or artifacts by default to avoid exposing PDFs/PII

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "scripts": {
     "test": "jest",
     "build:safari": "bash scripts/convert-safari.sh",
-    "test:e2e:web": "playwright test e2e/context-menu.spec.js e2e/dom-translate.spec.js e2e/translate-page.spec.js e2e/streaming-cancel.spec.js",
-    "test:e2e:pdf": "playwright test e2e/pdf-compare.spec.js",
-    "test:e2e": "npm run test:e2e:web && npm run test:e2e:pdf",
+    "test:e2e": "playwright test e2e",
     "e2e": "npm run test:e2e",
     "postinstall": "bash scripts/fetch-wasm-assets.sh",
     "clean": "rimraf dist",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -2,6 +2,7 @@
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 const config = {
   timeout: 120000,
+  fullyParallel: true,
   reporter: [['list'], ['html', { outputFolder: 'playwright-report', open: 'never' }]],
   use: {
     headless: true,


### PR DESCRIPTION
## Summary
- run all e2e specs in a single Playwright invocation
- enable full parallelization for Playwright tests
- update CI to use consolidated e2e script

## Testing
- `npm test --silent`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68a48266ca4883238543632fe00ddd54