### PR TITLE
chore(ci): reuse build artifacts for e2e smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
           name: dist
           path: dist/
 
+      - name: Upload node_modules
+        uses: actions/upload-artifact@v4
+        with:
+          name: node_modules
+          path: node_modules/
+
       - name: Upload zip
         uses: actions/upload-artifact@v4
         with:
@@ -67,11 +73,17 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: .
 
-      - name: Build dist
-        run: npm run build
+      - name: Download node_modules
+        uses: actions/download-artifact@v4
+        with:
+          name: node_modules
+          path: .
 
       - name: Install Playwright (Chromium + deps)
         run: npx playwright install --with-deps chromium


### PR DESCRIPTION
## Summary
- upload `node_modules` alongside `dist` in build-and-test job
- consume uploaded artifacts in e2e-smoke job to skip reinstalling and rebuilding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4826ed82083239ed174d610208cd2