### PR TITLE
chore(ci): reuse build artifacts for e2e smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+
       - name: Install dependencies
         run: npm ci
 
@@ -67,11 +74,17 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Restore node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
 
-      - name: Build dist
-        run: npm run build
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: .
 
       - name: Install Playwright (Chromium + deps)
         run: npx playwright install --with-deps chromium


### PR DESCRIPTION
## Summary
- cache `node_modules` during build-and-test to share with e2e job
- restore cached dependencies and downloaded dist in e2e-smoke to skip reinstall and rebuild

## Testing
- `npm test -- --ci --reporters=default`

------
https://chatgpt.com/codex/tasks/task_e_68a4826ed82083239ed174d610208cd2