### PR TITLE
test: cover context menu and selection bubble

### DIFF
--- a/e2e/context-menu.spec.js
+++ b/e2e/context-menu.spec.js
@@ -21,13 +21,15 @@ test('translates selected text via context menu', async ({ page }) => {
     window.qwenLoadConfig = async () => ({ apiKey: 'k', apiEndpoint: '', model: 'm', sourceLanguage: 'en', targetLanguage: 'fr', provider: 'mock', debug: false });
   });
   await page.goto(pageUrl);
-  await page.evaluate(() => window.__setTranslateStub());
-  await page.setContent('<p id="t">hello</p>');
   await page.addScriptTag({ content: contentScript });
+  await page.waitForFunction(() => window.__qwenMsg);
   await page.evaluate(() => {
-    const el = document.getElementById('t');
+    window.__setTranslateStub();
+    const p = document.querySelector('p');
+    p.id = 't';
+    p.textContent = 'hello';
     const range = document.createRange();
-    range.selectNodeContents(el);
+    range.selectNodeContents(p);
     const sel = window.getSelection();
     sel.removeAllRanges();
     sel.addRange(range);


### PR DESCRIPTION
## Summary
- test selection translation via context menu
- add selection bubble test for manual translation

## Testing
- `npm run test:e2e:web` *(fails: Missing script "test:e2e:web")*
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68a48b0b2a6483238c7e834d03321662