### PR TITLE
Split PDF e2e tests into conditional job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,3 @@
-# New file
 name: CI
 
 on:
@@ -54,7 +53,25 @@ jobs:
           name: qwen-translator-zip
           path: dist/*.zip
 
-  e2e-smoke:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      pdf: ${{ steps.filter.outputs.pdf }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            pdf:
+              - 'src/pdf**'
+              - 'e2e/pdfs/**'
+              - 'e2e/pdf-compare.spec.js'
+
+  e2e-web:
     needs: build-and-test
     runs-on: ubuntu-latest
     steps:
@@ -86,6 +103,43 @@ jobs:
       - name: Run e2e web smoke
         run: npm run test:e2e:web
 
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-web
+          path: playwright-report
+
+  e2e-pdf:
+    needs: [build-and-test, changes]
+    if: needs.changes.outputs.pdf == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-pdf-tests'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build dist
+        run: npm run build
+
+      - name: Install Playwright (Chromium + deps)
+        run: npx playwright install --with-deps chromium
+
+      - name: Start static server
+        run: |
+          nohup npx http-server . -p 8080 &
+          for i in {1..60}; do
+            curl -sSf http://127.0.0.1:8080 >/dev/null && break || sleep 1;
+          done
+
       - name: Run e2e PDF compare
         run: npm run test:e2e:pdf
 
@@ -93,11 +147,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-pdf
           path: playwright-report
 
   automerge:
-    needs: [build-and-test, e2e-smoke]
+    needs: [build-and-test, e2e-web]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,8 +4,9 @@ on:
   workflow_dispatch:
   push:
     paths:
-      - 'src/**'
-      - 'e2e/**'
+      - 'src/pdf**'
+      - 'e2e/pdfs/**'
+      - 'e2e/pdf-compare.spec.js'
       - '.github/workflows/e2e.yml'
       - 'package.json'
 
@@ -23,7 +24,7 @@ jobs:
           cache: 'npm'
 
       - name: Install deps
-        run: npm install --no-audit --no-fund
+        run: npm ci
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
@@ -39,6 +40,6 @@ jobs:
           fi
 
       - name: Run E2E tests
-        run: npm run e2e
+        run: npm run test:e2e:pdf
 
       # Privacy: do not upload screenshots or artifacts by default to avoid exposing PDFs/PII


### PR DESCRIPTION
## Summary
- run PDF compare tests in separate `e2e-pdf` job triggered by PDF path changes or `run-pdf-tests` label
- limit existing e2e job to lighter web smoke tests
- narrow PDF workflow triggers to PDF-related paths
- avoid auto-merge skipping when PDF tests don't run
- ensure `changes` job checks out repository before running `paths-filter`

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4827531d883238018d244b7898552