### PR TITLE
Consolidate popup styles into shared stylesheet

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -3,36 +3,10 @@
 <head>
   <meta charset="utf-8">
   <link rel="stylesheet" href="styles/apple.css">
-  <style>
-    html {
-      background: var(--qwen-bg, rgba(28,28,30,0.7));
-    }
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      color: var(--qwen-text, #f5f5f7);
-      margin: 0;
-      width: 300px; /* default width until iframe resizes */
-    }
-    #nav {
-      display: flex;
-      justify-content: flex-end;
-      padding: 0.5rem;
-    }
-    #nav button {
-      background: none;
-      border: none;
-      color: inherit;
-      cursor: pointer;
-      font-size: 1.25rem;
-    }
-    #content {
-      width: 100%;
-      border: 0;
-      display: block;
-    }
-  </style>
+  <link rel="stylesheet" href="styles/cyberpunk.css">
+  <link rel="stylesheet" href="styles/popup.css">
 </head>
-<body>
+<body class="popup">
   <header id="nav">
     <button id="settingsBtn" aria-label="Settings">⚙️</button>
   </header>

--- a/src/popup/diagnostics.html
+++ b/src/popup/diagnostics.html
@@ -3,16 +3,10 @@
 <head>
   <meta charset="utf-8">
   <link rel="stylesheet" href="../styles/apple.css">
-  <style>
-    html { min-height: 100%; background: var(--qwen-bg, rgba(28,28,30,0.7)); }
-    body { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif; margin:0; padding:1rem; color:var(--qwen-text,#f5f5f7); }
-    ul { list-style: none; padding: 0; }
-    li { margin-bottom: 0.25rem; }
-    .section { margin-bottom: 0.5rem; }
-    pre { white-space: pre-wrap; word-break: break-word; background: var(--qwen-secondary-bg, rgba(118,118,128,0.2)); padding:0.5rem; border-radius:4px; }
-  </style>
+  <link rel="stylesheet" href="../styles/cyberpunk.css">
+  <link rel="stylesheet" href="../styles/popup.css">
 </head>
-<body>
+<body class="diagnostics">
   <h3>Diagnostics</h3>
   <div class="section" id="status"></div>
   <div class="section" id="usage"></div>
@@ -23,7 +17,7 @@
   <canvas id="usageChart"></canvas>
   <div class="section">
     <h4>Latency Histogram</h4>
-    <canvas id="latencyHistogram" width="320" height="80" style="background: var(--qwen-secondary-bg, rgba(118,118,128,0.2)); border:1px solid var(--qwen-border, rgba(255,255,255,0.2)); border-radius:4px;"></canvas>
+    <canvas id="latencyHistogram" width="320" height="80"></canvas>
   </div>
   <div class="section" id="cache"></div>
   <ul id="providers"></ul>

--- a/src/popup/home.html
+++ b/src/popup/home.html
@@ -4,57 +4,16 @@
   <meta charset="utf-8">
   <link rel="stylesheet" href="../styles/apple.css">
   <link rel="stylesheet" href="../styles/cyberpunk.css">
-  <style>
-    html {
-      background: var(--qwen-bg, rgba(28,28,30,0.7));
-    }
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      color: var(--qwen-text, #f5f5f7);
-      margin: 0;
-      padding: 1rem;
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
-    }
-    .auto-toggle {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      font-size: 0.875rem;
-    }
-    .lang-select {
-      display: flex;
-      align-items: center;
-      gap: 0.25rem;
-    }
-    .lang-select select {
-      flex: 1;
-    }
-    .theme-select {
-      display: flex;
-      align-items: center;
-      gap: 0.25rem;
-    }
-    .theme-select select {
-      flex: 1;
-    }
-    .stats {
-      font-size: 0.75rem;
-    }
-    #providerKey {
-      margin-left: 0.25rem;
-    }
-  </style>
+  <link rel="stylesheet" href="../styles/popup.css">
 </head>
-<body>
+<body class="home">
   <button id="quickTranslate" class="primary">Translate page</button>
   <div class="lang-select">
     <select id="srcLang"></select>
     <span>→</span>
     <select id="destLang"></select>
   </div>
-  <div id="offlineBanner" class="stats" style="display:none;color:#ff6b6b">Offline: background reports no network. Translation may fail.</div>
+  <div id="offlineBanner" class="stats">Offline: background reports no network. Translation may fail.</div>
   <section id="perProvider">
     <h3>Per-provider usage</h3>
     <div id="providers"></div>

--- a/src/popup/providerEditor.html
+++ b/src/popup/providerEditor.html
@@ -1,8 +1,9 @@
-<div id="providerEditorOverlay" style="position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.6);display:none;align-items:center;justify-content:center;z-index:1000;">
-  <div style="background:var(--qwen-bg,rgba(28,28,30,0.9));padding:1rem;border:1px solid var(--qwen-border,rgba(255,255,255,0.2));min-width:260px;">
+<link rel="stylesheet" href="../styles/popup.css">
+<div id="providerEditorOverlay" class="overlay">
+  <div class="modal">
     <label data-field="apiKey">API Key <input id="pe_apiKey"></label>
     <label data-field="apiEndpoint">API Endpoint <input id="pe_apiEndpoint"></label>
-    <label data-field="model">Model <select id="pe_modelSelect" style="display:none"></select><input id="pe_modelInput"></label>
+    <label data-field="model">Model <select id="pe_modelSelect"></select><input id="pe_modelInput"></label>
     <details id="pe_advanced">
       <summary>Advanced</summary>
       <label data-field="requestLimit">Requests/min <input id="pe_requestLimit" type="number" min="0"></label>
@@ -18,7 +19,7 @@
       <label data-field="weight" title="Relative load-balancing preference when multiple providers are available">Weight <input id="pe_weight" type="number" step="0.01" min="0"></label>
       <p class="note">Higher = used more often when multiple providers have quota. <a href="https://github.com/MikkoParkkola/Qwen-translator-extension#pricing--load-balancing" target="_blank" rel="noopener">Learn more</a></p>
     </details>
-    <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-top:0.5rem;">
+    <div class="actions">
       <button id="pe_save">Save</button>
       <button id="pe_cancel">Cancel</button>
     </div>

--- a/src/popup/settings.html
+++ b/src/popup/settings.html
@@ -4,57 +4,9 @@
   <meta charset="utf-8">
   <link rel="stylesheet" href="../styles/apple.css">
   <link rel="stylesheet" href="../styles/cyberpunk.css">
-  <style>
-    html { min-height: 100%; background: var(--qwen-bg, rgba(28,28,30,0.7)); }
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      margin: 0;
-      padding: 1rem;
-      color: var(--qwen-text, #f5f5f7);
-      width: 360px;
-    }
-    .tabs { display: flex; gap: 0.5rem; margin-bottom: 0.5rem; }
-    .tabs button {
-      background: none;
-      border: 1px solid var(--qwen-border, rgba(255,255,255,0.2));
-      color: inherit;
-      padding: 0.25rem 0.5rem;
-      cursor: pointer;
-    }
-    .tabs button.active { background: var(--qwen-secondary-bg, rgba(118,118,128,0.2)); }
-    .tab { display: none; }
-    .tab.active { display: block; }
-    label { display: block; margin-bottom: 0.5rem; }
-    input[type="number"] { width: 5rem; }
-    textarea { width: 100%; }
-    .invalid { border-color: #ff4d4f; }
-    .note { font-size: 0.8rem; opacity: 0.8; }
-    .provider-card { display: flex; align-items: center; gap: 0.5rem; padding: 0.25rem; border: 1px solid var(--qwen-border, rgba(255,255,255,0.2)); margin-bottom: 0.25rem; }
-    .provider-card .drag-handle { cursor: move; }
-    #addProviderOverlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.6); display: none; align-items: center; justify-content: center; z-index: 1000; }
-    #addProviderOverlay .modal { background: var(--qwen-bg, rgba(28,28,30,0.9)); padding: 1rem; border: 1px solid var(--qwen-border, rgba(255,255,255,0.2)); min-width: 260px; }
-    #addProviderOverlay .actions { display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 0.5rem; }
-    #addProviderOverlay label { display: block; margin-bottom: 0.5rem; }
-    .tm-container {
-      max-height: 200px;
-      overflow-y: auto;
-      border: 1px solid var(--qwen-border, rgba(255,255,255,0.2));
-      padding: 0.25rem;
-      margin-bottom: 0.5rem;
-    }
-    #tmEntries, #tmStats {
-      white-space: pre-wrap;
-      word-break: break-word;
-      overflow-x: auto;
-      margin: 0;
-      width: 100%;
-    }
-    #tmStats {
-      margin-top: 0.5rem;
-    }
-  </style>
+  <link rel="stylesheet" href="../styles/popup.css">
 </head>
-<body>
+<body class="settings">
   <div class="tabs" role="tablist">
     <button data-tab="general" role="tab" aria-controls="generalTab">General</button>
     <button data-tab="providers" role="tab" aria-controls="providersTab">Providers</button>
@@ -124,7 +76,7 @@
         <pre id="tmStats">-</pre>
       </div>
       <button id="tmExport">Export</button>
-      <input type="file" id="tmImportFile" style="display:none">
+      <input type="file" id="tmImportFile">
       <button id="tmImport">Import</button>
       <button id="tmClear">Clear</button>
     </section>
@@ -145,7 +97,7 @@
     </section>
   </div>
 
-  <div id="addProviderOverlay">
+  <div id="addProviderOverlay" class="overlay">
     <div class="modal">
       <div id="ap_step1">
         <label>Preset
@@ -162,7 +114,7 @@
           <button id="ap_cancel1">Cancel</button>
         </div>
       </div>
-      <div id="ap_step2" style="display:none;">
+      <div id="ap_step2">
         <div id="ap_fields"></div>
         <div class="actions">
           <button id="ap_back">Back</button>

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -1,0 +1,220 @@
+html[data-qwen-theme] {
+  min-height: 100%;
+  background: var(--qwen-bg, rgba(28,28,30,0.7));
+}
+
+[data-qwen-theme] body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  color: var(--qwen-text, #f5f5f7);
+  margin: 0;
+  padding: 1rem;
+}
+
+[data-qwen-theme] body.home {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+[data-qwen-theme] body.settings {
+  width: 360px;
+}
+
+[data-qwen-theme] body.popup {
+  width: 300px;
+  padding: 0;
+}
+
+[data-qwen-theme] .auto-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+}
+
+[data-qwen-theme] .lang-select,
+[data-qwen-theme] .theme-select {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+[data-qwen-theme] .lang-select select,
+[data-qwen-theme] .theme-select select {
+  flex: 1;
+}
+
+[data-qwen-theme] .stats {
+  font-size: 0.75rem;
+}
+
+[data-qwen-theme] #providerKey {
+  margin-left: 0.25rem;
+}
+
+[data-qwen-theme] #offlineBanner {
+  display: none;
+  color: #ff6b6b;
+}
+
+[data-qwen-theme] .tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+[data-qwen-theme] .tabs button {
+  background: none;
+  border: 1px solid var(--qwen-border, rgba(255,255,255,0.2));
+  color: inherit;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+[data-qwen-theme] .tabs button.active {
+  background: var(--qwen-secondary-bg, rgba(118,118,128,0.2));
+}
+
+[data-qwen-theme] .tab {
+  display: none;
+}
+
+[data-qwen-theme] .tab.active {
+  display: block;
+}
+
+[data-qwen-theme] label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+[data-qwen-theme] input[type="number"] {
+  width: 5rem;
+}
+
+[data-qwen-theme] textarea {
+  width: 100%;
+}
+
+[data-qwen-theme] .invalid {
+  border-color: #ff4d4f;
+}
+
+[data-qwen-theme] .note {
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+
+[data-qwen-theme] .provider-card {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem;
+  border: 1px solid var(--qwen-border, rgba(255,255,255,0.2));
+  margin-bottom: 0.25rem;
+}
+
+[data-qwen-theme] .provider-card .drag-handle {
+  cursor: move;
+}
+
+[data-qwen-theme] .overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.6);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+[data-qwen-theme] .overlay .modal {
+  background: var(--qwen-bg, rgba(28,28,30,0.9));
+  padding: 1rem;
+  border: 1px solid var(--qwen-border, rgba(255,255,255,0.2));
+  min-width: 260px;
+}
+
+[data-qwen-theme] .overlay .actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+}
+
+[data-qwen-theme] .tm-container {
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid var(--qwen-border, rgba(255,255,255,0.2));
+  padding: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+[data-qwen-theme] #tmEntries,
+[data-qwen-theme] #tmStats {
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+  margin: 0;
+  width: 100%;
+}
+
+[data-qwen-theme] #tmStats {
+  margin-top: 0.5rem;
+}
+
+[data-qwen-theme] #tmImportFile,
+[data-qwen-theme] #pe_modelSelect,
+[data-qwen-theme] #ap_step2 {
+  display: none;
+}
+
+[data-qwen-theme] ul {
+  list-style: none;
+  padding: 0;
+}
+
+[data-qwen-theme] li {
+  margin-bottom: 0.25rem;
+}
+
+[data-qwen-theme] .section {
+  margin-bottom: 0.5rem;
+}
+
+[data-qwen-theme] pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--qwen-secondary-bg, rgba(118,118,128,0.2));
+  padding: 0.5rem;
+  border-radius: 4px;
+}
+
+[data-qwen-theme] #latencyHistogram {
+  background: var(--qwen-secondary-bg, rgba(118,118,128,0.2));
+  border: 1px solid var(--qwen-border, rgba(255,255,255,0.2));
+  border-radius: 4px;
+}
+
+[data-qwen-theme] #nav {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.5rem;
+}
+
+[data-qwen-theme] #nav button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.25rem;
+}
+
+[data-qwen-theme] #content {
+  width: 100%;
+  border: 0;
+  display: block;
+}


### PR DESCRIPTION
## Summary
- extract common popup layout and component styles into `src/styles/popup.css`
- load shared stylesheet in popup pages and remove inline styling
- ensure overlays and components use classes so themes override via `[data-qwen-theme]`

## Testing
- `npm test`
- Visually verified Apple and Cyberpunk themes

------
https://chatgpt.com/codex/tasks/task_e_68a49674ad70832397258bd4cf8dffc6