### PR TITLE
Rebase codex/enhance-pdf-compare-e2e-tests onto main

### DIFF
--- a/e2e/pdfs/hello.pdf
+++ b/e2e/pdfs/hello.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT /F1 24 Tf 72 100 Td (Hello) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f
+0000000010 00000 n
+0000000053 00000 n
+0000000100 00000 n
+0000000247 00000 n
+0000000336 00000 n
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+402
+%%EOF


### PR DESCRIPTION
## Summary
- rebase `codex/enhance-pdf-compare-e2e-tests` onto `main`
- keep up-to-date e2e script aliases in `package.json`
- ensure PDF overlay and progress e2e tests run on latest code

## Testing
- `npm test`
- `npm run test:e2e:pdf`


------
https://chatgpt.com/codex/tasks/task_e_68a49cbf7cc083239ab17c04ffbbda15