### PR TITLE
Make popup iframe responsive with adaptive styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.41.0",
+      "version": "1.42.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/popup.css
+++ b/src/popup.css
@@ -1,0 +1,52 @@
+html {
+  background: var(--qwen-bg, rgba(28,28,30,0.7));
+}
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  color: var(--qwen-text, #f5f5f7);
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  min-width: 260px;
+  max-width: 600px;
+  font-size: 1rem;
+}
+#nav {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.5rem;
+}
+#nav button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.25rem;
+}
+#content {
+  border: 0;
+  display: block;
+  flex: 1 1 auto;
+}
+@media (max-width: 319px) {
+  body {
+    font-size: 0.875rem;
+  }
+  #nav {
+    padding: 0.25rem;
+  }
+  #nav button {
+    font-size: 1rem;
+  }
+}
+@media (min-width: 480px) {
+  body {
+    font-size: 1.125rem;
+  }
+  #nav {
+    padding: 0.75rem;
+  }
+  #nav button {
+    font-size: 1.5rem;
+  }
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -3,34 +3,7 @@
 <head>
   <meta charset="utf-8">
   <link rel="stylesheet" href="styles/apple.css">
-  <style>
-    html {
-      background: var(--qwen-bg, rgba(28,28,30,0.7));
-    }
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      color: var(--qwen-text, #f5f5f7);
-      margin: 0;
-      width: 300px; /* default width until iframe resizes */
-    }
-    #nav {
-      display: flex;
-      justify-content: flex-end;
-      padding: 0.5rem;
-    }
-    #nav button {
-      background: none;
-      border: none;
-      color: inherit;
-      cursor: pointer;
-      font-size: 1.25rem;
-    }
-    #content {
-      width: 100%;
-      border: 0;
-      display: block;
-    }
-  </style>
+  <link rel="stylesheet" href="popup.css">
 </head>
 <body>
   <header id="nav">

--- a/src/popup/home.html
+++ b/src/popup/home.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="../styles/cyberpunk.css">
   <style>
     html {
+      height: 100%;
       background: var(--qwen-bg, rgba(28,28,30,0.7));
     }
     body {
@@ -16,6 +17,8 @@
       display: flex;
       flex-direction: column;
       gap: 0.75rem;
+      height: 100%;
+      overflow-y: auto;
     }
     .auto-toggle {
       display: flex;

--- a/src/popup/settings.html
+++ b/src/popup/settings.html
@@ -5,13 +5,17 @@
   <link rel="stylesheet" href="../styles/apple.css">
   <link rel="stylesheet" href="../styles/cyberpunk.css">
   <style>
-    html { min-height: 100%; background: var(--qwen-bg, rgba(28,28,30,0.7)); }
+    html { height: 100%; background: var(--qwen-bg, rgba(28,28,30,0.7)); }
     body {
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
       margin: 0;
       padding: 1rem;
       color: var(--qwen-text, #f5f5f7);
-      width: 360px;
+      min-width: 260px;
+      max-width: 600px;
+      box-sizing: border-box;
+      height: 100%;
+      overflow-y: auto;
     }
     .tabs { display: flex; gap: 0.5rem; margin-bottom: 0.5rem; }
     .tabs button {

--- a/updates.xml
+++ b/updates.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gupdate xmlns="http://www.google.com/update2/response" protocol="2.0">
   <app appid="YOUR_EXTENSION_ID">
-    <updatecheck codebase="https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/qwen-translator-extension.crx" version="1.34.0" />
+    <updatecheck codebase="https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/qwen-translator-extension.crx" version="1.42.0" />
   </app>
 </gupdate>


### PR DESCRIPTION
## Summary
- make popup width flexible via flex layout and min/max bounds
- add responsive popup CSS with width-based media queries
- allow home and settings pages to scroll when taller than viewport
- bump version to 1.42.0

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4967e57108323b27ebb2475f3c89a