### PR TITLE
Load cyberpunk styles in diagnostics popup

### DIFF
--- a/src/popup/diagnostics.html
+++ b/src/popup/diagnostics.html
@@ -3,21 +3,15 @@
 <head>
   <meta charset="utf-8">
   <link rel="stylesheet" href="../styles/apple.css">
-  <style>
-    html { min-height: 100%; background: var(--qwen-bg, rgba(28,28,30,0.7)); }
-    body { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif; margin:0; padding:1rem; color:var(--qwen-text,#f5f5f7); }
-    ul { list-style: none; padding: 0; }
-    li { margin-bottom: 0.25rem; }
-    .section { margin-bottom: 0.5rem; }
-    pre { white-space: pre-wrap; word-break: break-word; background: var(--qwen-secondary-bg, rgba(118,118,128,0.2)); padding:0.5rem; border-radius:4px; }
-  </style>
+  <link rel="stylesheet" href="../styles/cyberpunk.css">
+  <link rel="stylesheet" href="../styles/popup.css">
 </head>
 <body>
   <h3>Diagnostics</h3>
   <div class="section" id="status"></div>
   <div class="section" id="usage"></div>
   <div class="section" id="costs"></div>
-  <div class="section" id="costs"></div>
+  <div class="section" id="costSummary"></div>
   <div class="section" id="quality"></div>
   <div class="section" id="usageSummary"></div>
   <canvas id="usageChart"></canvas>

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -1,0 +1,6 @@
+html { min-height: 100%; background: var(--qwen-bg, rgba(28,28,30,0.7)); }
+body { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif; margin:0; padding:1rem; color:var(--qwen-text,#f5f5f7); }
+ul { list-style: none; padding: 0; }
+li { margin-bottom: 0.25rem; }
+.section { margin-bottom: 0.5rem; }
+pre { white-space: pre-wrap; word-break: break-word; background: var(--qwen-secondary-bg, rgba(118,118,128,0.2)); padding:0.5rem; border-radius:4px; }


### PR DESCRIPTION
## Summary
- Link diagnostics popup to cyberpunk theme and shared popup.css
- Replace duplicate `costs` ID with `costSummary`
- Move inline diagnostics styles to shared `popup.css`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4967cd6d48323a1f1b097d1b14588