### PR TITLE
Refactor modal and overlay styling

### DIFF
--- a/src/popup/providerEditor.html
+++ b/src/popup/providerEditor.html
@@ -1,6 +1,5 @@
-<link rel="stylesheet" href="../styles/popup.css">
-<div id="providerEditorOverlay" class="overlay">
-  <div class="modal">
+<div id="providerEditorOverlay" class="modal-overlay">
+  <div class="modal" role="dialog" aria-modal="true">
     <label data-field="apiKey">API Key <input id="pe_apiKey"></label>
     <label data-field="apiEndpoint">API Endpoint <input id="pe_apiEndpoint"></label>
     <label id="pe_modelLabel" data-field="model">Model <select id="pe_modelSelect" style="display:none" aria-labelledby="pe_modelLabel"></select><input id="pe_modelInput" aria-labelledby="pe_modelLabel"></label>

--- a/src/popup/providerEditor.js
+++ b/src/popup/providerEditor.js
@@ -16,6 +16,10 @@
   const advancedEl = overlay.querySelector('#pe_advanced');
   let currentId, cfg, refresh;
 
+  function close(){
+    overlay.style.display = 'none';
+  }
+
   function validUrl(u){
     if(!u) return true;
     try{ new URL(u); return true;}catch{return false;}
@@ -100,12 +104,18 @@
     if (!Array.isArray(cfg.providerOrder)) cfg.providerOrder = [];
     if (!cfg.providerOrder.includes(currentId)) cfg.providerOrder.push(currentId);
     window.qwenProviderConfig.saveProviderConfig(cfg);
-    overlay.style.display = 'none';
+    close();
     refresh?.();
   });
 
-  cancelBtn.addEventListener('click', () => {
-    overlay.style.display = 'none';
+  cancelBtn.addEventListener('click', close);
+
+  overlay.addEventListener('click', e => {
+    if (e.target === overlay) close();
+  });
+
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') close();
   });
 
   window.qwenProviderEditor = { open };

--- a/src/popup/settings.html
+++ b/src/popup/settings.html
@@ -98,8 +98,8 @@
     </section>
   </div>
 
-  <div id="addProviderOverlay" class="overlay">
-    <div class="modal">
+  <div id="addProviderOverlay" class="modal-overlay">
+    <div class="modal" role="dialog" aria-modal="true">
       <div id="ap_step1">
         <label>Preset
           <select id="ap_preset">

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -118,7 +118,7 @@ html[data-qwen-theme] {
   cursor: move;
 }
 
-[data-qwen-theme] .overlay {
+[data-qwen-theme] .modal-overlay {
   position: fixed;
   top: 0;
   left: 0;
@@ -131,14 +131,16 @@ html[data-qwen-theme] {
   z-index: 1000;
 }
 
-[data-qwen-theme] .overlay .modal {
+[data-qwen-theme] .modal {
   background: var(--qwen-bg, rgba(28,28,30,0.9));
   padding: 1rem;
   border: 1px solid var(--qwen-border, rgba(255,255,255,0.2));
   min-width: 260px;
+  max-width: calc(100% - 2rem);
+  box-sizing: border-box;
 }
 
-[data-qwen-theme] .overlay .actions {
+[data-qwen-theme] .modal .actions {
   display: flex;
   gap: 0.5rem;
   justify-content: flex-end;


### PR DESCRIPTION
## Summary
- Replace generic overlay with dedicated modal-overlay container and role attributes
- Centralize modal layout styles in popup.css

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a4456a9c832391d2d1ee1a993e51