### PR TITLE
test: run e2e smoke on Firefox and WebKit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,8 @@ jobs:
           name: dist
           path: .
 
-      - name: Install Playwright (Chromium + deps)
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium firefox webkit
 
       - name: Start static server
         run: |
@@ -114,7 +114,7 @@ jobs:
           done
 
       - name: Run e2e web smoke
-        run: npm run test:e2e-web
+        run: npm run test:e2e-web -- --browser=chromium,firefox,webkit
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Install deps
         run: npm ci
 
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium firefox webkit
 
       - name: Check repo for public PDFs at root (privacy)
         run: |
@@ -47,6 +47,6 @@ jobs:
           fi
 
       - name: Run E2E tests
-        run: npm run test:e2e-pdf
+        run: npm run test:e2e-pdf -- --browser=chromium,firefox,webkit
 
       # Privacy: do not upload screenshots or artifacts by default to avoid exposing PDFs/PII

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -9,6 +9,11 @@ const config = {
     viewport: { width: 1200, height: 900 },
   },
   testDir: 'e2e',
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+    { name: 'firefox', use: { browserName: 'firefox' } },
+    { name: 'webkit', use: { browserName: 'webkit' } },
+  ],
   webServer: {
     command: "npx http-server -p 8080 -c-1 . -H 'Permissions-Policy: accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=()'",
     url: 'http://127.0.0.1:8080',


### PR DESCRIPTION
## Summary
- run Playwright e2e smoke tests in Chromium, Firefox, and WebKit
- enable cross-browser PDF compare workflow
- configure Playwright projects for all three browsers

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a805983c832390f041d182ec302f