### PR TITLE
fix: share popup styles on diagnostics page

### DIFF
--- a/src/popup/diagnostics.html
+++ b/src/popup/diagnostics.html
@@ -11,7 +11,7 @@
   <div class="section" id="status"></div>
   <div class="section" id="usage"></div>
   <div class="section" id="costs"></div>
-  <div class="section" id="costs"></div>
+  <div class="section" id="costSummary"></div>
   <div class="section" id="quality"></div>
   <div class="section" id="usageSummary"></div>
   <canvas id="usageChart"></canvas>


### PR DESCRIPTION
## Summary
- rebase branch onto latest main
- link diagnostics page to shared popup stylesheet
- remove duplicate cost section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ab6c469483238fef50bf49e2c98f