### PR TITLE
Add bundle size check and batching benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Build dist
         run: npm run build
 
+      - name: Check bundle size
+        run: npm run size
+
       - name: Build ZIP artifact
         run: npm run build:zip
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.54.2",
+        "@size-limit/file": "^11.1.5",
         "@types/jest": "^30.0.0",
         "bestzip": "^2.2.1",
         "copyfiles": "^2.4.1",
@@ -29,6 +30,7 @@
         "pdf-lib": "^1.17.1",
         "prettier": "^3.3.2",
         "rimraf": "^6.0.1",
+        "size-limit": "^11.1.5",
         "typescript": "^5.9.2"
       }
     },
@@ -1681,6 +1683,19 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@size-limit/file": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-11.2.0.tgz",
+      "integrity": "sha512-OZHE3putEkQ/fgzz3Tp/0hSmfVo3wyTpOJSRNm6AmcwX4Nm9YtTfbQQ/hZRwbBFR23S7x2Sd9EbqYzngKwbRoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "11.2.0"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -2786,6 +2801,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2900,6 +2925,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/chownr": {
@@ -5568,6 +5609,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
+      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5761,6 +5812,19 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
       }
     },
     "node_modules/lines-and-columns": {
@@ -6023,6 +6087,16 @@
       "resolved": "https://registry.npmjs.org/mupdf/-/mupdf-1.26.4.tgz",
       "integrity": "sha512-lv+0KCowetjXu/80h1WKDsELnvHvt7zAE4cs3TC92gwbbJk8AJifMpPLRHMWFovvsWXdFZ6KKCGRds3EzA9TlQ==",
       "license": "AGPL-3.0-or-later"
+    },
+    "node_modules/nanospinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1"
+      }
     },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
@@ -6843,6 +6917,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7247,6 +7335,28 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/size-limit": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-11.2.0.tgz",
+      "integrity": "sha512-2kpQq2DD/pRpx3Tal/qRW1SYwcIeQ0iq8li5CJHQgOC+FtPn2BVmuDtzUCgNnpCrbgtfEHqh+iWzxK+Tq6C+RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "chokidar": "^4.0.3",
+        "jiti": "^2.4.2",
+        "lilconfig": "^3.1.3",
+        "nanospinner": "^1.2.2",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.11"
+      },
+      "bin": {
+        "size-limit": "bin.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/slash": {
@@ -7662,6 +7772,54 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tldts": {

--- a/package.json
+++ b/package.json
@@ -14,14 +14,15 @@
     "e2e": "npm run test:e2e",
     "postinstall": "bash scripts/fetch-wasm-assets.sh",
     "clean": "rimraf dist",
-    "build": "npm run clean && copyfiles -u 1 src/**/* dist",
+    "build": "rimraf dist && copyfiles -u 1 \"src/**/*\" dist",
     "zip": "bestzip dist/qwen-translator-v$npm_package_version.zip dist/*",
     "build:zip": "npm run build && npm run zip",
     "serve": "http-server dist -p 8080",
     "lint": "eslint .",
     "format": "prettier --check package.json",
     "typecheck": "tsc --noEmit",
-    "typecheck:popup": "tsc --noEmit types/popup/*.d.ts"
+    "typecheck:popup": "tsc --noEmit types/popup/*.d.ts",
+    "size": "npm run build && size-limit"
   },
   "keywords": [],
   "author": "",
@@ -44,6 +45,12 @@
       ]
     }
   },
+  "size-limit": [
+    {
+      "path": "dist/translator.js",
+      "limit": "60 KB"
+    }
+  ],
   "devDependencies": {
     "@playwright/test": "^1.54.2",
     "@types/jest": "^30.0.0",
@@ -60,7 +67,9 @@
     "eslint": "^8.57.0",
     "prettier": "^3.3.2",
     "rimraf": "^6.0.1",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "@size-limit/file": "^11.1.5",
+    "size-limit": "^11.1.5"
   },
   "dependencies": {
     "mupdf": "^1.26.4",

--- a/test/pipeline.test.js
+++ b/test/pipeline.test.js
@@ -1,5 +1,7 @@
 const fs = require('fs');
 const path = require('path');
+const { performance } = require('perf_hooks');
+const { splitLongText } = require('../src/translator/batching');
 
 function loadPipeline() {
   const code = fs.readFileSync(path.join(__dirname, '../src/wasm/pipeline.js'), 'utf8');
@@ -37,5 +39,17 @@ describe('regeneratePdfFromUrl when engine missing', () => {
       regeneratePdfFromUrl('https://example.com/a.pdf', { useWasmEngine: true })
     ).rejects.toThrow('WASM engine not available');
     expect(global.chrome.downloads.download).not.toHaveBeenCalled();
+  });
+});
+
+describe('translator batching performance', () => {
+  it('splits text under threshold', () => {
+    const text = 'Hello world. '.repeat(1000);
+    const start = performance.now();
+    for (let i = 0; i < 100; i++) {
+      splitLongText(text, 500);
+    }
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(120);
   });
 });


### PR DESCRIPTION
## Summary
- add size-limit config and npm script for bundle size checks
- enforce bundle size limit in CI workflow
- add translator batching performance benchmark test
- ensure size script rebuilds dist before measuring bundle size

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run size`


------
https://chatgpt.com/codex/tasks/task_e_68a4b42c9ff483238c8bbdd91bd886aa