### PR TITLE
fix: resize popup when TM entries are long

### DIFF
--- a/dist/popup/settings.html
+++ b/dist/popup/settings.html
@@ -37,9 +37,18 @@
     #addProviderOverlay .modal { background: var(--qwen-bg, rgba(28,28,30,0.9)); padding: 1rem; border: 1px solid var(--qwen-border, rgba(255,255,255,0.2)); min-width: 260px; }
     #addProviderOverlay .actions { display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 0.5rem; }
     #addProviderOverlay label { display: block; margin-bottom: 0.5rem; }
+    .tm-container {
+      max-height: 200px;
+      overflow-y: auto;
+      overflow-x: hidden;
+      border: 1px solid var(--qwen-border, rgba(255,255,255,0.2));
+      padding: 0.25rem;
+      margin-bottom: 0.5rem;
+    }
     #tmEntries, #tmStats {
       white-space: pre-wrap;
       word-break: break-word;
+      overflow-wrap: anywhere;
       overflow-x: hidden;
     }
   </style>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.34.0",
-  "version_name": "2025-08-19",
+  "version": "1.35.0",
+  "version_name": "2025-08-20",
   "update_url": "https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/updates.xml",
   "permissions": [
     "storage",

--- a/src/popup/settings.js
+++ b/src/popup/settings.js
@@ -64,8 +64,11 @@
     diagnostics: document.getElementById('diagnosticsTab'),
   };
 
-  const fixedWidth = document.body.clientWidth;
-  document.body.style.width = `${fixedWidth}px`;
+  function updateWidth() {
+    document.body.style.width = 'auto';
+    const width = document.body.scrollWidth;
+    document.body.style.width = `${width}px`;
+  }
 
   function activate(tab) {
     tabs.forEach(b => {
@@ -77,7 +80,7 @@
     Object.entries(sections).forEach(([k, el]) => {
       el.classList.toggle('active', k === tab);
     });
-    document.body.style.width = `${fixedWidth}px`;
+    updateWidth();
   }
 
   activate(store.settingsTab);
@@ -390,6 +393,7 @@
     const stats = res.stats || {};
     tmEntriesEl.textContent = JSON.stringify(entries, null, 2);
     tmStatsEl.textContent = JSON.stringify(stats, null, 2);
+    updateWidth();
   }
 
   document.getElementById('tmClear')?.addEventListener('click', async () => {

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -184,6 +184,7 @@ html[data-qwen-theme] {
 [data-qwen-theme] .tm-container {
   max-height: 200px;
   overflow-y: auto;
+  overflow-x: hidden;
   border: 1px solid var(--qwen-border, rgba(255,255,255,0.2));
   padding: 0.25rem;
   margin-bottom: 0.5rem;
@@ -193,6 +194,7 @@ html[data-qwen-theme] {
 [data-qwen-theme] #tmStats {
   white-space: pre-wrap;
   word-break: break-word;
+  overflow-wrap: anywhere;
   overflow-x: hidden;
   margin: 0;
   width: 100%;


### PR DESCRIPTION
## Summary
- ensure translation memory entries wrap and container hides horizontal overflow
- recalc popup width on tab change so settings dialog shrinks back after visiting Advanced
- bump manifest version

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4b71e98848323b0e0e635cc56d52a