### PR TITLE
Add workflow for signed Chrome packages

### DIFF
--- a/.github/workflows/sign-extension.yml
+++ b/.github/workflows/sign-extension.yml
@@ -1,0 +1,32 @@
+name: Sign Chrome Extension
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Decode signing key
+        env:
+          CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
+        run: |
+          echo "$CRX_PRIVATE_KEY" | base64 -d > key.pem
+      - name: Pack and sign
+        run: |
+          npx -y crx pack dist -o qwen-translator-extension.crx --zip-output qwen-translator-extension.zip -p key.pem
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: signed-extension
+          path: |
+            qwen-translator-extension.crx
+            qwen-translator-extension.zip
+      - run: rm key.pem

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ npm run build:safari
 Open the generated project in Xcode to sign and build the extension for the desired platform.
 See `safari/README.md` for detailed iOS/iPadOS deployment steps.
 
+## Packaging and Signing
+The repository includes a workflow that builds and signs a Chrome extension package.
+
+1. Open the **Actions** tab and run **Sign Chrome Extension**.
+2. The job builds the project, signs it using the `CRX_PRIVATE_KEY` secret, and uploads `qwen-translator-extension.crx` and `qwen-translator-extension.zip` as artifacts.
+
+To sign locally:
+
+```sh
+npm run build
+echo "$CRX_PRIVATE_KEY" | base64 -d > key.pem
+npx -y crx pack dist -o qwen-translator-extension.crx --zip-output qwen-translator-extension.zip -p key.pem
+```
+
 ## Configuration
 Open the popup and click the ⚙️ button to access **Settings**. The settings page provides:
 - **General** – toggle automatic language detection and manage the glossary.


### PR DESCRIPTION
## Summary
- add Sign Chrome Extension workflow that builds and signs CRX packages
- document packaging and signing steps in README

## Testing
- `npm run lint`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4b75f9b808323ab66bae20de5e7f7