### PR TITLE
chore: sign and version extension build artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,17 +22,25 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npm run build:zip
-      - name: Prepare update files
+      - name: Decode signing key
+        env:
+          CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
+        run: |
+          echo "$CRX_PRIVATE_KEY" | base64 -d > key.pem
+      - name: Package and sign extension
         run: |
           VERSION=$(jq -r .version src/manifest.json)
-          CRX_NAME="qwen-translator-extension.crx"
-          mv dist/*.zip "$CRX_NAME"
+          NAME="qwen-translator-extension-${VERSION}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "NAME=$NAME" >> $GITHUB_ENV
+          npx -y crx pack dist -o "$NAME.crx" --zip-output "$NAME.zip" -p key.pem
+      - name: Prepare update files
+        run: |
           cat <<XML > updates.xml
 <?xml version="1.0" encoding="UTF-8"?>
 <gupdate xmlns="http://www.google.com/update2/response" protocol="2.0">
   <app appid="${EXTENSION_ID}">
-    <updatecheck codebase="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/main/${CRX_NAME}" version="${VERSION}" />
+    <updatecheck codebase="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/main/${NAME}.crx" version="${VERSION}" />
   </app>
 </gupdate>
 XML
@@ -40,6 +48,7 @@ XML
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git add updates.xml qwen-translator-extension.crx
+          git add updates.xml "${NAME}.crx" "${NAME}.zip"
           git commit -m "chore: update dev build [skip ci]" || echo "No changes to commit"
           git push
+      - run: rm key.pem

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,7 @@ Popup header displays the product name beside the settings button.
   - Auto-translate only starts for the active tab; background tabs remain untouched until activated.
 - Build/CI
   - Reproducible dist + zip; CI builds/tests and uploads artifacts on push/PR.
+  - `publish.yml` signs each main-branch build with `CRX_PRIVATE_KEY`, emitting `qwen-translator-extension-<version>.zip` and a matching signed `.crx`.
 
 ## TODO / Next Steps
 - Content multi-provider propagation


### PR DESCRIPTION
## Summary
- sign Chrome extension during publish workflow using repo private key
- generate versioned zip and crx artifacts on main branch builds
- document new signing workflow in AGENTS.md

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm audit`
- `npx gitleaks detect --no-banner` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dc2deb0083238c3c18cb4ba8baee