### PR TITLE
chore: document and configure merge queue

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,21 @@
+name: coverage
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci --no-audit --no-fund
+      - run: npm test -- --coverage
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,19 +1,18 @@
-name: test
+name: lint
 
 on:
   push:
   pull_request:
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
       - run: npm ci --no-audit --no-fund
-      - run: npm test
+      - run: npm run lint
+      - run: npm run format

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,15 @@ Popup header displays the product name beside the settings button.
 - Commits: imperative, present tense (e.g., "Replace PDF text …"). Optional prefixes `feat:`, `fix:`, `chore:` are welcome when meaningful.
 - PRs: clear description, linked issue, test plan, and screenshots/GIFs for UI changes (PDF viewer, content script). Note any config changes.
 
+## Merge Queue
+- A GitHub merge queue (via Bors) serializes merges to keep `main` green.
+- Required checks: `lint`, `test`, and `coverage` must succeed before a PR enters the queue.
+- Queue a PR with `bors r+`. Use `bors r-` to remove it or `bors retry` after fixing failures.
+- Troubleshooting:
+  - Verify the Bors GitHub App is installed and `bors.toml` exists on `main`.
+  - Ensure the branch is up to date and all required checks are green.
+  - If the queue is stuck, check Bors logs and repository permissions.
+
 ## Definition of Done
 - Implement features using test-driven development (write failing tests first).
 - Update unit, integration, and end-to-end test automation.

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,1 @@
+status = ["lint", "test", "coverage"]


### PR DESCRIPTION
## Summary
- document merge queue usage
- add bors config requiring lint, test, and coverage
- split lint, test, and coverage into dedicated workflows

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npm test -- --coverage`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_68a4e427f9008323af45d39d91b723f6