### PR TITLE
chore: add PR automation script

### DIFF
--- a/.changeset/pr-helper-script.md
+++ b/.changeset/pr-helper-script.md
@@ -1,0 +1,5 @@
+---
+"translate-by-mikko": patch
+---
+
+Add automation script for creating pull requests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,24 @@ Popup header displays the product name beside the settings button.
 - Load in Chrome: chrome://extensions → Developer mode → Load unpacked → select `dist/`.
 - CI: `.github/workflows/ci.yml` runs tests, builds dist/zip, uploads artifacts, and executes Playwright e2e smoke tests (Chromium) on push/PR.
 - Local PDF viewer: open `src/pdfViewer.html` (uses `config.local.js` when present).
+- `npm run pr`: Automates PR creation. Requires `BRANCH_NAME` and `COMMIT_MESSAGE` env vars and an authenticated `gh` CLI. Optionals: `PR_TITLE`, `PR_BODY`, `BASE_BRANCH` (default `main`). Checks for merge conflicts before pushing, runs lint/format/tests, commits, pushes, opens a PR, and enables auto-merge.
+
+### PR Automation Usage
+
+```bash
+BRANCH_NAME=my-branch \
+COMMIT_MESSAGE="chore: describe change" \
+npm run pr
+```
+
+Environment variables:
+
+- `BRANCH_NAME` (required): new branch name.
+- `COMMIT_MESSAGE` (required): Conventional commit message.
+- `PR_TITLE` (optional): PR title (defaults to `COMMIT_MESSAGE`).
+- `PR_BODY` (optional): PR description.
+- `BASE_BRANCH` (optional): target branch, defaults to `main`.
+- `GITHUB_TOKEN`/`GH_TOKEN`: token for the GitHub CLI.
 
 ## Testing Guidelines
 - Run `npm run lint` and `npm run format` before `npm test`.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "typecheck:popup": "tsc --noEmit types/popup/*.d.ts",
     "size": "npm run build && size-limit",
     "changeset": "changeset",
-    "release": "changeset publish"
+    "release": "changeset publish",
+    "pr": "bash scripts/pr.sh"
   },
   "keywords": [],
   "author": "",

--- a/scripts/pr.sh
+++ b/scripts/pr.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_BRANCH="${BASE_BRANCH:-main}"
+BRANCH_NAME="${BRANCH_NAME:-}"
+COMMIT_MESSAGE="${COMMIT_MESSAGE:-}"
+PR_TITLE="${PR_TITLE:-}"
+PR_BODY="${PR_BODY:-}"
+
+if [[ -z "$BRANCH_NAME" ]]; then
+  echo "BRANCH_NAME is required" >&2
+  exit 1
+fi
+
+if [[ -z "$COMMIT_MESSAGE" ]]; then
+  echo "COMMIT_MESSAGE is required" >&2
+  exit 1
+fi
+
+# Ensure we're up to date and create branch
+git fetch origin "$BASE_BRANCH"
+git checkout -b "$BRANCH_NAME"
+
+npm run lint
+npm run format
+npm test
+
+# Commit changes
+git add -A
+git commit -m "$COMMIT_MESSAGE"
+
+# Check for merge conflicts before pushing
+if ! git merge --no-commit --no-ff "origin/$BASE_BRANCH"; then
+  echo "Merge conflict detected with $BASE_BRANCH. Aborting." >&2
+  git merge --abort || true
+  exit 1
+fi
+git merge --abort || true
+
+# Push and open PR with auto-merge
+git push -u origin "$BRANCH_NAME"
+
+gh pr create --base "$BASE_BRANCH" --head "$BRANCH_NAME" \
+  --title "${PR_TITLE:-$COMMIT_MESSAGE}" --body "${PR_BODY:-}"
+
+gh pr merge --auto --squash


### PR DESCRIPTION
## What
- add `npm run pr` script to automate branch creation, checks, commit, push, and PR auto-merge
- document usage and env vars in `AGENTS.md`

## Why
- streamline contributor workflow and enforce checks before opening a PR

## How
- bash script `scripts/pr.sh` orchestrates lint, format, tests, merge conflict check, push, `gh pr create`, and `gh pr merge --auto`
- exposes env vars to configure branch name, commit message, PR metadata, and base branch

## Tests
- Unit: `npm test`
- Integration: N/A
- E2E/Contract: N/A
- Coverage: N/A

## Security & Perf
- SAST/SCA/Secrets/IaC/Container: `npm audit`
- Performance budgets: `npm run size`

## Risks & Rollback
- Risks identified: relies on authenticated `gh` CLI; merge conflict check may miss complex rebases
- Rollback plan: revert script and docs

## Docs
- AGENTS.md/ADR/diagrams updated

## Checklist
- [x] Conventional Commit used
- [ ] Changelog auto-updates correctly
- [ ] Preview environment link(s) included


------
https://chatgpt.com/codex/tasks/task_e_68a4ee085d28832390d54d3fd3b53d78