### PR TITLE
ci: automate releases with changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": ["@changesets/changelog-github", {"repo": "owner/repo"}],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: changesets/action@v1
         with:
           publish: npm publish
+          createGithubRelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,13 +65,14 @@ Environment variables:
 - Selection/DOM flows (`e2e/context-menu.spec.js`, `e2e/dom-translate.spec.js`, `e2e/translate-page.spec.js`, `e2e/streaming-cancel.spec.js`) run via `npm run test:e2e:web`; PDF compare (`e2e/pdf-compare.spec.js`) runs via `npm run test:e2e:pdf`. `npm run test:e2e` executes both suites. CI job `e2e-smoke` installs Chromium (`npx playwright install --with-deps chromium`), serves `dist/`, and runs the suites headless.
 
 ## Commit & Pull Request Guidelines
-- Commits follow [Conventional Commits](https://www.conventionalcommits.org/) in imperative present tense (`feat:`, `fix:`, `chore:`, `docs:`, etc.).
-- PRs: clear description, linked issue, test plan, and screenshots/GIFs for UI changes (PDF viewer, content script). Note any config changes.
+- Commits follow [Conventional Commits](https://www.conventionalcommits.org/) in imperative present tense (`feat:`, `fix:`, `chore:`, `docs:` etc.).
+- Every functional change must include a `changeset` entry created via `npx changeset`.
+- PRs require a clear description, linked issue, test plan, and screenshots/GIFs for UI changes (PDF viewer, content script). Note any config changes.
 
 ## Release Workflow
 - Versioning and changelogs use [Changesets](https://github.com/changesets/changesets).
-- Run `npx changeset` with each change to record release notes.
-- When merges land on `main`, a GitHub Action versions the repo and publishes the release.
+- On merges to `main`, `.github/workflows/release.yml` runs `changesets/action@v1` to publish to npm and create a GitHub release.
+- `release.yml` requires `GITHUB_TOKEN` and `NPM_TOKEN` secrets for publishing.
 
 ## Merge Queue
 - A GitHub merge queue (via Bors) serializes merges to keep `main` green.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "pdfjs-dist": "^5.4.54"
       },
       "devDependencies": {
+        "@changesets/changelog-github": "^0.5.1",
         "@changesets/cli": "^2.29.6",
         "@playwright/test": "^1.54.2",
         "@size-limit/file": "^11.1.5",
@@ -665,6 +666,18 @@
         "@changesets/types": "^6.1.0"
       }
     },
+    "node_modules/@changesets/changelog-github": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.5.1.tgz",
+      "integrity": "sha512-BVuHtF+hrhUScSoHnJwTELB4/INQxVFc+P/Qdt20BLiBFIHFJDDUaGsZw+8fQeJTRP5hJZrzpt3oZWh0G19rAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/get-github-info": "^0.6.0",
+        "@changesets/types": "^6.1.0",
+        "dotenv": "^8.1.0"
+      }
+    },
     "node_modules/@changesets/cli": {
       "version": "2.29.6",
       "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.29.6.tgz",
@@ -800,6 +813,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@changesets/get-github-info": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.6.0.tgz",
+      "integrity": "sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dataloader": "^1.4.0",
+        "node-fetch": "^2.5.0"
       }
     },
     "node_modules/@changesets/get-release-plan": {
@@ -3892,6 +3916,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/dataloader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
+      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -4035,6 +4066,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   ],
   "devDependencies": {
     "@changesets/cli": "^2.29.6",
+    "@changesets/changelog-github": "^0.5.1",
     "@playwright/test": "^1.54.2",
     "@size-limit/file": "^11.1.5",
     "@types/jest": "^30.0.0",


### PR DESCRIPTION
## What
- automate changelog generation and releases via changesets

## Why
- publish npm and GitHub releases automatically on merges to main

## How
- add `@changesets/changelog-github` dev dependency
- configure release workflow to create GitHub releases
- document Conventional Commits and release process

## Tests
- Unit: `npm test`
- Integration:
- E2E/Contract:
- Coverage: N/A

## Security & Perf
- SAST/SCA/Secrets/IaC/Container: N/A
- Performance budgets: N/A

## Risks & Rollback
- Risks identified: release automation misconfiguration
- Rollback plan: revert workflow changes

## Docs
- AGENTS.md updated

## Checklist
- [x] Conventional Commit used
- [ ] Changelog auto-updates correctly
- [ ] Preview environment link(s) included


------
https://chatgpt.com/codex/tasks/task_e_68a4fc4bc2d88323a96ba4c67624b640