### PR TITLE
docs: add nightly rebase policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,4 +167,8 @@ Press `Ctrl+C` or `Ctrl+D` to exit.
 ### TypeScript
 Basic type definitions for the translator APIs ship in `types/index.d.ts` and are referenced via the package `types` field.
 
+## Nightly Rebase
+
+A scheduled workflow rebases all open pull requests each night to keep branches current with `main`. Pull requests with merge conflicts are skipped and the workflow tags the author. Contributors should resolve conflicts promptly so their branch can re-enter the merge queue. See [AGENTS.md#nightly-rebase](AGENTS.md#nightly-rebase) for full details.
+
 Trigger CI re-run.


### PR DESCRIPTION
## What
- document nightly rebase workflow in README

## Why
- inform contributors about nightly rebase requirement

## How
- add "Nightly Rebase" section referencing `AGENTS.md#nightly-rebase`

## Tests
- Unit: `npm test`
- Integration: N/A
- E2E/Contract: N/A
- Coverage: N/A

## Security & Perf
- SAST/SCA/Secrets/IaC/Container: N/A
- Performance budgets: N/A

## Risks & Rollback
- Risks identified: minimal
- Rollback plan: revert commit

## Docs
- AGENTS.md/ADR/diagrams updated: N/A

## Checklist
- [x] Conventional Commit used
- [ ] Changelog auto-updates correctly
- [ ] Preview environment link(s) included

------
https://chatgpt.com/codex/tasks/task_e_68a51e1f24348323a63ab77db98eb941