### PR TITLE
test: mock canvas context in diagnostics chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TRANSLATE! by Mikko
 
+*Formerly known as Qwen Translator Extension.*
+
 This Chrome extension translates the content of the active tab using multiple providers. Dynamic pages are translated as new elements appear. It supports translation between more than one hundred languages.
 
 ## Installation

--- a/test/diagnosticsChart.test.js
+++ b/test/diagnosticsChart.test.js
@@ -14,6 +14,32 @@ describe('diagnostics chart', () => {
       <button id="back"></button>
       <button id="copy"></button>
     `;
+    HTMLCanvasElement.prototype.getContext = () => ({
+      fillRect: jest.fn(),
+      clearRect: jest.fn(),
+      getImageData: jest.fn(() => ({ data: [] })),
+      putImageData: jest.fn(),
+      createImageData: jest.fn(),
+      setTransform: jest.fn(),
+      drawImage: jest.fn(),
+      save: jest.fn(),
+      fillText: jest.fn(),
+      restore: jest.fn(),
+      beginPath: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      closePath: jest.fn(),
+      stroke: jest.fn(),
+      translate: jest.fn(),
+      scale: jest.fn(),
+      rotate: jest.fn(),
+      arc: jest.fn(),
+      fill: jest.fn(),
+      measureText: jest.fn(() => ({ width: 0 })),
+      transform: jest.fn(),
+      rect: jest.fn(),
+      clip: jest.fn()
+    });
     global.Chart = jest.fn(() => ({
       data: { labels: [], datasets: [{ data: [] }, { data: [] }] },
       update: jest.fn()
@@ -72,6 +98,32 @@ describe('diagnostics chart', () => {
         <button id="back"></button>
         <button id="copy"></button>
       `;
+      HTMLCanvasElement.prototype.getContext = () => ({
+        fillRect: jest.fn(),
+        clearRect: jest.fn(),
+        getImageData: jest.fn(() => ({ data: [] })),
+        putImageData: jest.fn(),
+        createImageData: jest.fn(),
+        setTransform: jest.fn(),
+        drawImage: jest.fn(),
+        save: jest.fn(),
+        fillText: jest.fn(),
+        restore: jest.fn(),
+        beginPath: jest.fn(),
+        moveTo: jest.fn(),
+        lineTo: jest.fn(),
+        closePath: jest.fn(),
+        stroke: jest.fn(),
+        translate: jest.fn(),
+        scale: jest.fn(),
+        rotate: jest.fn(),
+        arc: jest.fn(),
+        fill: jest.fn(),
+        measureText: jest.fn(() => ({ width: 0 })),
+        transform: jest.fn(),
+        rect: jest.fn(),
+        clip: jest.fn()
+      });
       global.Chart = jest.fn(() => ({
         data: { labels: [], datasets: [{ data: [] }, { data: [] }] },
         update: jest.fn()


### PR DESCRIPTION
## What
- stub `HTMLCanvasElement.getContext` in diagnostics chart tests
- document previous project name in README

## Why
- tests failed under jsdom without a canvas context
- README lacked note about rename from Qwen Translator Extension

## How
- Architecture & design decisions (ADR ref if any)
- API/schema changes
- Feature flags & rollout plan

## Tests
- Unit: `npm test`
- Integration:
- E2E/Contract:
- Coverage: see `npm test -- --coverage`

## Security & Perf
- SAST/SCA/Secrets/IaC/Container: `npm audit`, `npm run secrets`
- Performance budgets: `npm run size`

## Risks & Rollback
- Risks identified: low; doc and test only
- Rollback plan: remove `test/diagnosticsChart.test.js` and revert commit (`git revert <commit>`)

## Docs
- AGENTS.md/ADR/diagrams updated

## Checklist
- [ ] Conventional Commit used
- [ ] Changelog auto-updates correctly
- [ ] Preview environment link(s) included


------
https://chatgpt.com/codex/tasks/task_e_68a5476a16ec8323bcca6d89e0dd62c6