### PR TITLE
docs: clarify changeset usage

### DIFF
--- a/.changeset/wide-spiders-bow.md
+++ b/.changeset/wide-spiders-bow.md
@@ -1,2 +1,5 @@
 ---
+"translate-by-mikko": none
 ---
+
+docs: clarify changeset usage for documentation updates

--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ Press `Ctrl+C` or `Ctrl+D` to exit.
 
 Basic type definitions for the translator APIs ship in `types/index.d.ts` and are referenced via the package `types` field.
 
+## Contributing
+
+Use [Changesets](https://github.com/changesets/changesets) for all substantive updates. Documentation-only changes should set the release type to `none` so the package version remains the same. These entries are skipped in the published changelog.
+
 ## Nightly Rebase
 
 A scheduled workflow rebases open pull requests nightly to keep branches current with `main`. Pull requests with merge conflicts are skipped and the workflow tags the author, who must resolve conflicts promptly so their branch can re-enter the merge queue. See [AGENTS.md#nightly-rebase](AGENTS.md#nightly-rebase) for full details.


### PR DESCRIPTION
## What
- clarify that documentation-only changes use Changesets with `none`
- note that such changes are omitted from the changelog

## Why
- avoid unintended version bumps for docs updates

## How
- add documentation section describing `none` release type
- add accompanying changeset marked `none`

## Tests
- Unit: `npm test`
- Integration: N/A
- E2E/Contract: N/A
- Coverage: N/A

## Security & Perf
- SAST/SCA/Secrets/IaC/Container: OK
- Performance budgets: OK

## Risks & Rollback
- Risks identified: none
- Rollback plan: revert commit

## Docs
- AGENTS.md/ADR/diagrams updated: README

## Checklist
- [x] Conventional Commit used
- [ ] Changelog auto-updates correctly
- [ ] Preview environment link(s) included

------
https://chatgpt.com/codex/tasks/task_e_68a54d3d67f48323aa0744e7b50b8f9d