### PR TITLE
fix: redact token fields in logger

### DIFF
--- a/.changeset/redact-token-logger.md
+++ b/.changeset/redact-token-logger.md
@@ -1,0 +1,4 @@
+---
+"translate-by-mikko": patch
+---
+fix: redact tokens in logger

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Popup header displays the product name beside the settings button.
 - Popup: `popup.html` loads `popup/home.html` and `popup/settings.html` (provider management).
 - Providers: `src/providers/{qwen,dashscope,openai,deepl,google,openrouter,anthropic,mistral,ollama,macos}.js` (registered via `src/lib/providers.js`).
 - Messaging: `src/lib/messaging.js` (Port + legacy sendMessage fallback).
-- Logging: `src/lib/logger.js` (centralized logger with redaction).
+- Logging: `src/lib/logger.js` (centralized logger with redaction of Authorization, apiKey, and token fields).
 - Translation Memory (TM): `src/lib/tm.js` (IndexedDB TTL/LRU + metrics).
 - Detection: `src/lib/detect.js` (local heuristic; background also supports optional Google detection).
 - Batch delimiter: `src/lib/batchDelim.js` (collision-resistant delimiters).

--- a/dist/lib/logger.js
+++ b/dist/lib/logger.js
@@ -9,16 +9,20 @@
     const s = String(l || '').toLowerCase();
     return LEVELS[s] ?? 1;
   }
+  function isSecretKey(k) {
+    return /^authorization$/i.test(k) || /^api(?:[-_\s]?key)$/i.test(k) || /token/i.test(k);
+  }
   function redactValue(v) {
     if (typeof v === 'string') {
       return v
         .replace(/(api[-_\s]?key\s*[:=]\s*).*/ig, '$1<redacted>')
-        .replace(/(authorization\s*[:=]\s*).*/ig, '$1<redacted>');
+        .replace(/(authorization\s*[:=]\s*).*/ig, '$1<redacted>')
+        .replace(/(token\s*[:=]\s*).*/ig, '$1<redacted>');
     }
     if (v instanceof Error) {
       const out = {};
       for (const k of Object.getOwnPropertyNames(v)) {
-        if (/^authorization$/i.test(k) || /^api(?:[-_\s]?key)$/i.test(k)) {
+        if (isSecretKey(k)) {
           out[k] = '<redacted>';
         } else {
           out[k] = redactValue(v[k]);
@@ -32,7 +36,7 @@
     if (v && typeof v === 'object') {
       const out = Array.isArray(v) ? [] : {};
       for (const k of Object.keys(v)) {
-        if (/^authorization$/i.test(k) || /^api(?:[-_\s]?key)$/i.test(k)) {
+        if (isSecretKey(k)) {
           out[k] = '<redacted>';
         } else {
           out[k] = redactValue(v[k]);

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -9,16 +9,20 @@
     const s = String(l || '').toLowerCase();
     return LEVELS[s] ?? 1;
   }
+  function isSecretKey(k) {
+    return /^authorization$/i.test(k) || /^api(?:[-_\s]?key)$/i.test(k) || /token/i.test(k);
+  }
   function redactValue(v) {
     if (typeof v === 'string') {
       return v
         .replace(/(api[-_\s]?key\s*[:=]\s*).*/ig, '$1<redacted>')
-        .replace(/(authorization\s*[:=]\s*).*/ig, '$1<redacted>');
+        .replace(/(authorization\s*[:=]\s*).*/ig, '$1<redacted>')
+        .replace(/(token\s*[:=]\s*).*/ig, '$1<redacted>');
     }
     if (v instanceof Error) {
       const out = {};
       for (const k of Object.getOwnPropertyNames(v)) {
-        if (/^authorization$/i.test(k) || /^api(?:[-_\s]?key)$/i.test(k)) {
+        if (isSecretKey(k)) {
           out[k] = '<redacted>';
         } else {
           out[k] = redactValue(v[k]);
@@ -32,7 +36,7 @@
     if (v && typeof v === 'object') {
       const out = Array.isArray(v) ? [] : {};
       for (const k of Object.keys(v)) {
-        if (/^authorization$/i.test(k) || /^api(?:[-_\s]?key)$/i.test(k)) {
+        if (isSecretKey(k)) {
           out[k] = '<redacted>';
         } else {
           out[k] = redactValue(v[k]);

--- a/test/logger.redaction.test.js
+++ b/test/logger.redaction.test.js
@@ -105,6 +105,22 @@
     expect(dump).not.toMatch(/SECRET|ERRKEY|ARR|HEAD/);
   });
 
+  test('redacts tokens in strings and objects', () => {
+    const logger = require('../src/lib/logger.js');
+    const log = logger.create('test');
+    log.setLevel(3);
+
+    log.debug('token=abc123', 'Bearer token: secret');
+    log.info('accessToken: xyz', { refresh_token: 'foo' });
+
+    const flat = outputs
+      .flatMap(([_, args]) => args)
+      .map(a => (typeof a === 'string' ? a : JSON.stringify(a)))
+      .join(' ');
+    expect(flat).toMatch(/token\s*[=:]\s*<redacted>/i);
+    expect(flat).not.toMatch(/abc123|secret|xyz|foo/);
+  });
+
   test('parseLevel handles numbers and strings', () => {
     const { parseLevel } = require('../src/lib/logger.js');
     expect(parseLevel('debug')).toBe(3);


### PR DESCRIPTION
## What
Redact token fields in logger to prevent leaking credentials.

## Why
Logging token values could expose secrets; ensure tokens are redacted.

## How
- Added token key detection in logger redaction
- Updated unit tests and build artifacts
- Documented redaction in AGENTS

## Tests
- Unit: `npm test test/logger.redaction.test.js`
- Integration: `npm test`
- E2E/Contract: n/a
- Coverage: 61.82%

## Security & Perf
- SAST/SCA/Secrets/IaC/Container: `npm audit` 0 vulnerabilities, `npm run secrets` no leaks
- Performance budgets: `npm run size` (8.41 kB < 60 kB limit)

## Risks & Rollback
- Risks identified: none
- Rollback plan: revert commit

## Docs
- AGENTS.md/ADR/diagrams updated

## Checklist
- [x] Conventional Commit used
- [ ] Changelog auto-updates correctly
- [ ] Preview environment link(s) included


------
https://chatgpt.com/codex/tasks/task_e_68a55339abb88323ac29796e80c506f3