### PR TITLE
fix: show per-provider usage in popup home

### DIFF
--- a/.changeset/per-provider-usage.md
+++ b/.changeset/per-provider-usage.md
@@ -1,0 +1,4 @@
+---
+"translate-by-mikko": patch
+---
+fix: include per-provider usage in home init

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,9 +197,10 @@ Environment variables:
   - Add minimum-signal threshold for very short tokens to reduce misclassification; optional sensitivity setting.
 - Observability
   - Optional background debug endpoint to expose TM/cache metrics; Advanced UI readout in popup.
-  - Diagnostics popup displays real-time throttle usage, cache stats, TM hits, and translation status via `stats` messages.
-  - Advanced control for in-memory LRU size (`QWEN_MEMCACHE_MAX`) with validation.
-  - Popup diagnostics log each step at info level and content-script batch translations log start/finish for easier troubleshooting.
+- Diagnostics popup displays real-time throttle usage, cache stats, TM hits, and translation status via `stats` messages.
+- Advanced control for in-memory LRU size (`QWEN_MEMCACHE_MAX`) with validation.
+- Popup diagnostics log each step at info level and content-script batch translations log start/finish for easier troubleshooting.
+- Home popup shows per-provider usage cards using metrics from the background script.
 - Provider ecosystem
   - Add additional providers (Azure OpenAI, Anthropic/Claude) behind registry; extend error normalization tests accordingly.
 - Typed interfaces

--- a/src/popup.js
+++ b/src/popup.js
@@ -106,9 +106,10 @@
           const usage = metrics && metrics.usage ? metrics.usage : {};
           const cache = metrics && metrics.cache ? metrics.cache : {};
           const tm = metrics && metrics.tm ? metrics.tm : {};
+          const provUsage = metrics && metrics.providersUsage ? metrics.providersUsage : {};
           const apiKey = !!(metrics && metrics.providers && metrics.providers[provider] && metrics.providers[provider].apiKey);
           const active = metrics && metrics.status ? !!metrics.status.active : false;
-          sendResponse({ provider, apiKey, usage, cache, tm, auto: autoCfg.autoTranslate, active });
+          sendResponse({ provider, apiKey, usage, cache, tm, providers: provUsage, auto: autoCfg.autoTranslate, active });
         });
         return true;
       case 'home:get-usage':

--- a/test/popup.providers.test.js
+++ b/test/popup.providers.test.js
@@ -1,0 +1,32 @@
+// @jest-environment jsdom
+
+describe('popup home:init includes provider usage', () => {
+  let listener;
+  beforeEach(() => {
+    jest.resetModules();
+    global.chrome = {
+      runtime: {
+        sendMessage: jest.fn((msg, cb) => {
+          if (msg.action === 'metrics') {
+            cb({
+              usage: {},
+              cache: {},
+              tm: {},
+              providers: {},
+              providersUsage: { qwen: { requests: 1 } },
+              status: {},
+            });
+          }
+        }),
+        onMessage: { addListener: fn => { listener = fn; } },
+      },
+      storage: { sync: { get: jest.fn((defaults, cb) => cb(defaults)) } },
+    };
+    require('../src/popup.js');
+  });
+
+  test('returns providers usage', async () => {
+    const res = await new Promise(resolve => listener({ action: 'home:init' }, {}, resolve));
+    expect(res.providers).toEqual({ qwen: { requests: 1 } });
+  });
+});


### PR DESCRIPTION
## What
- display per-provider usage on popup home

## Why
- per-provider usage section was empty

## How
- include per-provider usage metrics in home init response
- test coverage for provider usage snapshot

## Tests
- `npm run lint`
- `npm run format`
- `npm test`
- `npm audit`
- `npm run secrets`

## Security & Perf
- SAST/SCA/Secrets/IaC/Container: OK
- Performance budgets: OK

## Risks & Rollback
- Risks identified: none
- Rollback plan: revert commit

## Docs
- AGENTS.md updated

## Checklist
- [x] Conventional Commit used
- [ ] Changelog auto-updates correctly
- [ ] Preview environment link(s) included


------
https://chatgpt.com/codex/tasks/task_e_68a780877254832382fdad528f5faf5e