### PR TITLE
fix: skip translating non-source language strings

### DIFF
--- a/.changeset/skip-non-source.md
+++ b/.changeset/skip-non-source.md
@@ -1,0 +1,5 @@
+---
+"translate-by-mikko": patch
+---
+
+fix: skip translating strings outside the selected source language

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,7 @@ Environment variables:
   - Auto-detect source via local heuristic; optional Google detection in background using `detectApiKey`.
   - Mixed-language batching: per-text detection and language-clustered requests for accuracy.
   - Skips translation when source language matches target to avoid redundant work.
+  - When a fixed source language is set, each string is still language-detected; strings detected as a different language are returned unchanged.
 - Caching / TM
   - TM (IndexedDB) with TTL/LRU and metrics; optional chrome.storage.sync/WebDAV/iCloud sync with user toggle and remote clear; warmed before batching; skips re-translation of hits and diagnostics panel shows hit/miss counts.
   - In-memory LRU with normalized keys (whitespace collapsed + NFC) limits memory and improves hit rate.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "translate-by-mikko",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "translate-by-mikko",
-      "version": "1.44.0",
+      "version": "1.44.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translate-by-mikko",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "description": "Extension to translate web pages using multiple providers",
   "main": "index.js",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "TRANSLATE! by Mikko",
   "description": "Translate pages using multiple providers",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "version_name": "2025-08-21",
   "update_url": "https://raw.githubusercontent.com/QwenLM/translate-by-mikko/main/updates.xml",
   "permissions": [

--- a/test/provider.failover.test.js
+++ b/test/provider.failover.test.js
@@ -1,5 +1,9 @@
- // New file
- // @jest-environment node
+// New file
+// @jest-environment node
+
+jest.mock('../src/lib/detect.js', () => ({
+  detectLocal: (t) => ({ lang: /hola/i.test(String(t)) ? 'es' : 'en', confidence: 1 })
+}));
 
  describe('provider failover', () => {
    beforeEach(() => {

--- a/test/translator.fixedsource.test.js
+++ b/test/translator.fixedsource.test.js
@@ -1,0 +1,73 @@
+// @jest-environment node
+
+jest.mock('../src/lib/detect.js', () => ({
+  detectLocal: (t) => ({
+    lang: /hallo/i.test(String(t)) ? 'nl' : /bonjour/i.test(String(t)) ? 'fr' : 'en',
+    confidence: 0.9,
+  }),
+}));
+
+describe('fixed source language translation', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('qwenTranslate translates only matching source language', async () => {
+    const Providers = require('../src/lib/providers.js');
+    const spy = jest.fn(async ({ text, source }) => ({ text: `SRC:${source}:${text}` }));
+    Providers.register('dashscope', { translate: spy });
+    Providers.init();
+    const { qwenTranslate } = require('../src/translator.js');
+
+    const dutch = await qwenTranslate({
+      text: 'hallo wereld',
+      source: 'nl',
+      target: 'en',
+      endpoint: 'https://dashscope-intl.aliyuncs.com/api/v1',
+      model: 'm',
+      noProxy: true,
+    });
+    expect(dutch.text.startsWith('SRC:nl:')).toBe(true);
+
+    const french = await qwenTranslate({
+      text: 'bonjour',
+      source: 'nl',
+      target: 'en',
+      endpoint: 'https://dashscope-intl.aliyuncs.com/api/v1',
+      model: 'm',
+      noProxy: true,
+    });
+    expect(french.text).toBe('bonjour');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('qwenTranslateBatch skips non-source language texts', async () => {
+    const Providers = require('../src/lib/providers.js');
+    const translateMock = jest.fn(async ({ text, source }) => {
+      const m = String(text).match(/<<<QWEN_SPLIT_[A-Za-z0-9]+_[A-Za-z0-9]+>>>/);
+      const sep = m ? m[0] : '\uE000';
+      const parts = String(text).split(sep);
+      const out = parts.map((p) => `S:${source}:${p}`).join(sep);
+      return { text: out };
+    });
+    Providers.register('dashscope', { translate: translateMock });
+    Providers.init();
+    const { qwenTranslateBatch } = require('../src/translator.js');
+    const res = await qwenTranslateBatch({
+      texts: ['hallo wereld', 'bonjour', 'hello'],
+      source: 'nl',
+      target: 'en',
+      endpoint: 'https://dashscope-intl.aliyuncs.com/api/v1',
+      model: 'm',
+      tokenBudget: 10000,
+      maxBatchSize: 200,
+      noProxy: true,
+    });
+    expect(res.texts[0].startsWith('S:nl:')).toBe(true);
+    expect(res.texts[1]).toBe('bonjour');
+    expect(res.texts[2]).toBe('hello');
+    expect(translateMock).toHaveBeenCalledTimes(1);
+    const langs = translateMock.mock.calls.map((c) => c[0].source);
+    expect(new Set(langs)).toEqual(new Set(['nl']));
+  });
+});

--- a/updates.xml
+++ b/updates.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gupdate xmlns="http://www.google.com/update2/response" protocol="2.0">
   <app appid="YOUR_EXTENSION_ID">
-    <updatecheck codebase="https://raw.githubusercontent.com/QwenLM/translate-by-mikko/main/translate-by-mikko-1.44.0.crx" version="1.44.0" />
+    <updatecheck codebase="https://raw.githubusercontent.com/QwenLM/translate-by-mikko/main/translate-by-mikko-1.44.1.crx" version="1.44.1" />
   </app>
 </gupdate>


### PR DESCRIPTION
## What
- skip translating strings not in the selected source language
- document language filtering rule

## Why
- avoid unnecessary translations when fixed source language is used

## How
- detect language for each string and bypass translation when it differs from the user-selected source
- update tests and metadata

## Tests
- `npm run lint`
- `npm run format`
- `npm test -- --coverage`
- `npm audit`
- `npm run secrets`
- `npm run size`

## Security & Perf
- SAST/SCA/Secrets/IaC/Container: OK
- Performance budgets: OK

## Risks & Rollback
- Risks identified: language detection may misclassify and skip valid translations
- Rollback plan: revert commit

## Docs
- AGENTS.md updated

## Checklist
- [x] Conventional Commit used
- [x] Changelog auto-updates correctly
- [ ] Preview environment link(s) included


------
https://chatgpt.com/codex/tasks/task_e_68a7819ddd508323a4ae5380307b7685